### PR TITLE
Change the sensorname for imu sensors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,9 @@
 *.out
 *.app
 
+# vs code directory
+.vscode/
+
 # Build directory
 build*/
+

--- a/urdf/simmechanics/data/ergocub/ERGOCUB_all_options.yaml
+++ b/urdf/simmechanics/data/ergocub/ERGOCUB_all_options.yaml
@@ -801,7 +801,8 @@ sensors:
     updateRate: "100"
   - frameName: SCSYS_HEAD_IMU
     linkName: head
-    sensorName: head_imu_acc_1x1
+    sensorName: head_imu_0
+    exportFrameInURDF: Yes
     sensorType: "accelerometer"
     sensorBlobs:
     - |
@@ -891,7 +892,8 @@ sensors:
   # the imu measurements are referred to the depth frame.
   - frameName: SCSYS_HEAD_DEPTH
     linkName: realsense
-    sensorName: realsense_imu_acc_1x1
+    sensorName: realsense_imu_0
+    exportFrameInURDF: Yes
     sensorType: "accelerometer"
     sensorBlobs:
     - |

--- a/urdf/simmechanics/data/ergocub/ERGOCUB_all_options_gazebo.yaml.in
+++ b/urdf/simmechanics/data/ergocub/ERGOCUB_all_options_gazebo.yaml.in
@@ -797,7 +797,8 @@ sensors:
     updateRate: "100"
   - frameName: SCSYS_HEAD_IMU
     linkName: head
-    sensorName: head_imu_acc_1x1
+    sensorName: head_imu_0
+    exportFrameInURDF: Yes
     sensorType: "accelerometer"
     sensorBlobs:
     - |
@@ -887,7 +888,8 @@ sensors:
   # the imu measurements are referred to the depth frame.
   - frameName: SCSYS_HEAD_DEPTH
     linkName: realsense
-    sensorName: realsense_imu_acc_1x1
+    sensorName: realsense_imu_0
+    exportFrameInURDF: Yes
     sensorType: "accelerometer"
     sensorBlobs:
     - |


### PR DESCRIPTION
It fixes #36 

The name has been changed in order to be the same one used on the real robot (https://github.com/robotology/robots-configuration/pull/422)