### PR TITLE
ergoCubSN000: remove ft sensors in the legs

### DIFF
--- a/urdf/simmechanics/data/ergocub/ERGOCUB_all_options.yaml
+++ b/urdf/simmechanics/data/ergocub/ERGOCUB_all_options.yaml
@@ -723,15 +723,15 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://ergoCub/conf/FT/gazebo_ergocub_right_arm_ft.ini</yarpConfigurationFile>
           </plugin>
     # left leg
-    - jointName: l_leg_ft_sensor
-      directionChildToParent: Yes
-      frame: sensor
-      frameName: SCSYS_L_HIP_2_FT
-      sensorBlobs:
-      - |
-          <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-            <yarpConfigurationFile>model://ergoCub/conf/FT/gazebo_ergocub_left_leg_ft.ini</yarpConfigurationFile>
-          </plugin>
+    # - jointName: l_leg_ft_sensor
+    #   directionChildToParent: Yes
+    #   frame: sensor
+    #   frameName: SCSYS_L_HIP_2_FT
+    #   sensorBlobs:
+    #   - |
+    #       <plugin name="left_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+    #         <yarpConfigurationFile>model://ergoCub/conf/FT/gazebo_ergocub_left_leg_ft.ini</yarpConfigurationFile>
+    #       </plugin>
     - jointName: l_foot_front_ft_sensor
       directionChildToParent: No
       frame: sensor
@@ -751,15 +751,15 @@ forceTorqueSensors:
             <yarpConfigurationFile>model://ergoCub/conf/FT/gazebo_ergocub_left_foot_rear_ft.ini</yarpConfigurationFile>
           </plugin>
     # right leg
-    - jointName: r_leg_ft_sensor
-      directionChildToParent: Yes
-      frame: sensor
-      frameName: SCSYS_R_HIP_2_FT
-      sensorBlobs:
-      - |
-          <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
-            <yarpConfigurationFile>model://ergoCub/conf/FT/gazebo_ergocub_right_leg_ft.ini</yarpConfigurationFile>
-          </plugin>
+    # - jointName: r_leg_ft_sensor
+    #   directionChildToParent: Yes
+    #   frame: sensor
+    #   frameName: SCSYS_R_HIP_2_FT
+    #   sensorBlobs:
+    #   - |
+    #       <plugin name="right_leg_ft_plugin" filename="libgazebo_yarp_forcetorque.so">
+    #         <yarpConfigurationFile>model://ergoCub/conf/FT/gazebo_ergocub_right_leg_ft.ini</yarpConfigurationFile>
+    #       </plugin>
     - jointName: r_foot_front_ft_sensor
       directionChildToParent: No
       frame: sensor


### PR DESCRIPTION
For now, we remove  the hip ft sensors from the model of `ergoCubSN000` since on the real robot the ones mounted are dummy

see https://github.com/icub-tech-iit/ergocub-software/issues/43#issuecomment-1422312202

 