### PR TITLE
Reverse rotation of camera tilt and left shoulder yaw in URDF

### DIFF
--- a/tests/ergocub-model-test.cpp
+++ b/tests/ergocub-model-test.cpp
@@ -308,7 +308,7 @@ bool checkAxisDirections(iDynTree::KinDynComputations & comp)
     axisNames.push_back("l_shoulder_roll");
     expectedDirectionInRootLink.push_back(iDynTree::Direction(0.961047,-0.271447,0.0520081));
     axisNames.push_back("l_shoulder_yaw");
-    expectedDirectionInRootLink.push_back(iDynTree::Direction(-0.116648,-0.227771,0.966702));
+    expectedDirectionInRootLink.push_back(iDynTree::Direction(0.116648,0.227771,-0.966702));
     axisNames.push_back("l_elbow");
     expectedDirectionInRootLink.push_back(iDynTree::Direction(-0.250563,-0.935113,-0.250563));
     axisNames.push_back("l_wrist_roll");

--- a/urdf/simmechanics/data/ergocub/ERGOCUB_all_options.yaml
+++ b/urdf/simmechanics/data/ergocub/ERGOCUB_all_options.yaml
@@ -1042,6 +1042,7 @@ reverseRotationAxis:
     torso_pitch
     torso_yaw
     neck_yaw
+    camera_tilt
     l_thumb_prox
     l_thumb_dist
     l_index_add

--- a/urdf/simmechanics/data/ergocub/ERGOCUB_all_options.yaml
+++ b/urdf/simmechanics/data/ergocub/ERGOCUB_all_options.yaml
@@ -1028,6 +1028,7 @@ assignedColors:
 reverseRotationAxis:
     l_shoulder_pitch
     l_shoulder_roll
+    l_shoulder_yaw
     r_elbow
     l_wrist_pitch
     r_wrist_yaw
@@ -1053,7 +1054,6 @@ reverseRotationAxis:
 #    r_knee
 #    r_ankle_roll
 #    l_ankle_pitch
-#    l_shoulder_yaw
 #    l_wrist_roll
 #    l_wrist_pitch
 #    l_wrist_yaw

--- a/urdf/simmechanics/data/ergocub/ERGOCUB_all_options_gazebo.yaml.in
+++ b/urdf/simmechanics/data/ergocub/ERGOCUB_all_options_gazebo.yaml.in
@@ -1239,6 +1239,7 @@ reverseRotationAxis:
     torso_pitch
     torso_yaw
     neck_yaw
+    camera_tilt
     l_thumb_prox
     l_thumb_dist
     l_index_add

--- a/urdf/simmechanics/data/ergocub/ERGOCUB_all_options_gazebo.yaml.in
+++ b/urdf/simmechanics/data/ergocub/ERGOCUB_all_options_gazebo.yaml.in
@@ -1225,6 +1225,7 @@ assignedColors:
 reverseRotationAxis:
     l_shoulder_pitch
     l_shoulder_roll
+    l_shoulder_yaw
     r_elbow
     l_wrist_pitch
     r_wrist_yaw


### PR DESCRIPTION
In accordance to the real ergoCub, this PR reverses `camera_tilt` and `l_shoulder_yaw`, so that:
- Positive tilt points upwards
- Positive yaw rotates along an axis oriented towards the hand

Addresses: https://github.com/icub-tech-iit/ergocub-software/issues/47

cc @lrapetti 