### PR TITLE
Fix rpy angles of waist_imu

### DIFF
--- a/urdf/simmechanics/data/ergocub/ERGOCUB_all_options.yaml
+++ b/urdf/simmechanics/data/ergocub/ERGOCUB_all_options.yaml
@@ -1032,7 +1032,7 @@ XMLBlobs:
             <link name="waist_imu_0"/>
     - |  
             <joint name="waist_imu_0_fixed_joint" type="fixed">
-              <origin xyz="0.0354497 0.00639688 0.060600" rpy="-1.5707322 1.5707963 0"/>
+              <origin xyz="0.0354497 0.00639688 0.060600" rpy="-1.5708 0 1.5708"/>
               <parent link="torso_1"/>
               <child link="waist_imu_0"/>
               <dynamics damping="0.1"/>
@@ -1048,7 +1048,7 @@ XMLBlobs:
             <sensor name="waist_imu_0" type="imu">
             <always_on>1</always_on>
             <update_rate>100</update_rate>
-            <pose>0.0354497 0.00639688 0.060600 -1.5707322 1.5707963 0</pose>
+            <pose>0.0354497 0.00639688 0.060600 -1.5708 0 1.5708</pose>
             <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
             <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_waist_inertial.ini</yarpConfigurationFile>
             </plugin>
@@ -1057,7 +1057,7 @@ XMLBlobs:
     - |
             <sensor name="waist_imu_0" type="accelerometer">
             <parent link="torso_1"/>
-            <origin rpy="-1.5707322 1.5707963 0" xyz="0.0354497 0.00639688 0.060600"/>
+            <origin rpy="-1.5708 0 1.5708" xyz="0.0354497 0.00639688 0.060600"/>
             </sensor>
     # upperbody
     - |

--- a/urdf/simmechanics/data/ergocub/ERGOCUB_all_options_gazebo.yaml.in
+++ b/urdf/simmechanics/data/ergocub/ERGOCUB_all_options_gazebo.yaml.in
@@ -1226,7 +1226,7 @@ XMLBlobs:
             <link name="waist_imu_0"/>
     - |
             <joint name="waist_imu_0_fixed_joint" type="fixed">
-              <origin xyz="0.0354497 0.00639688 0.060600" rpy="-1.5707322 1.5707963 0"/>
+              <origin xyz="0.0354497 0.00639688 0.060600" rpy="-1.5708 0 1.5708"/>
               <parent link="torso_1"/>
               <child link="waist_imu_0"/>
               <dynamics damping="0.1"/>
@@ -1242,7 +1242,7 @@ XMLBlobs:
             <sensor name="waist_imu_0" type="imu">
             <always_on>1</always_on>
             <update_rate>100</update_rate>
-            <pose>0.0354497 0.00639688 0.060600 -1.5707322 1.5707963 0</pose>
+            <pose>0.0354497 0.00639688 0.060600 -1.5708 0 1.5708</pose>
             <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
             <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_waist_inertial.ini</yarpConfigurationFile>
             </plugin>
@@ -1251,7 +1251,7 @@ XMLBlobs:
     - |
             <sensor name="waist_imu_0" type="accelerometer">
             <parent link="torso_1"/>
-            <origin rpy="-1.5707322 1.5707963 0" xyz="0.0354497 0.00639688 0.060600"/>
+            <origin rpy="-1.5708 0 1.5708" xyz="0.0354497 0.00639688 0.060600"/>
             </sensor>
     # upperbody
     - |


### PR DESCRIPTION
After some tests on gazebo in order to test whether the `waist_imu` was correctly put inside the urdf model, I found out an error in the rpy angles. This PR aims to fix this error. 

Now, by reading the accelerometer through `yarp read ... /ergocubSim/waist/inertials/measurements:o`, I'm able to read the gravity acceleration in the opposite direction of the y axis, in accordance to the cad.


![MicrosoftTeams-image (4)](https://user-images.githubusercontent.com/114698424/237057428-9d3f195d-dee8-4810-aabc-7f30085d0e92.png)
