### PR TITLE
Update torso_joints number in all-mc_remapper.xml after removing torso_pitch

### DIFF
--- a/urdf/simmechanics/data/ergocub/conf/wrappers/motorControl/all-mc_remapper.xml
+++ b/urdf/simmechanics/data/ergocub/conf/wrappers/motorControl/all-mc_remapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints_mc" type="controlboardremapper">
+    <paramlist name="networks">
+        <elem name="head_joints1">( 0 3 0 3 )</elem>
+        <elem name="left_arm_joints1">( 4 10 0 6 )</elem>
+        <elem name="left_arm_joints2">( 11 16 0 5 )</elem>
+        <elem name="right_arm_joints1">( 17 23 0 6 )</elem>
+        <elem name="right_arm_joints2">( 24 29 0 5 )</elem>
+        <elem name="torso_joints">( 30 31  0 1 )</elem>
+        <elem name="left_leg_joints1">( 32 37  0 5 )</elem>
+        <elem name="right_leg_joints1">( 38 43  0 5 )</elem>
+    </paramlist>
+    <param name="period"> 0.010 </param>
+    <param name="joints"> 44 </param>
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="head_joints1">head_hardware_device</elem>
+            <elem name="left_arm_joints1">left_arm_hardware_device</elem>
+            <elem name="left_arm_joints2">left_hand_hardware_device</elem>
+            <elem name="right_arm_joints1">right_arm_hardware_device</elem>
+            <elem name="right_arm_joints2">right_hand_hardware_device</elem>
+            <elem name="torso_joints">torso_hardware_device</elem>
+            <elem name="left_leg_joints1">left_leg-mc_remapper</elem>
+            <elem name="right_leg_joints1">right_leg-mc_remapper</elem>
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/urdf/simmechanics/data/ergocub/conf/wrappers/motorControl/all-mc_remapper_ros2.xml
+++ b/urdf/simmechanics/data/ergocub/conf/wrappers/motorControl/all-mc_remapper_ros2.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+    <device xmlns:xi="http://www.w3.org/2001/XInclude" name="cbw_ros2" type="controlBoard_nws_ros2">
+        <param name="node_name"> ros2_cb_node </param>
+        <param name="topic_name"> /joint_states </param>
+        <param name="period"> 0.010 </param>
+        <action phase="startup" level="7" type="attach">
+            <param name="device"> alljoints_mc </param>
+        </action>
+        <action phase="shutdown" level="3" type="detach" />
+    </device>


### PR DESCRIPTION
I added the `all-mc_remapper.xml` and `all-mc_remapper_ros2.xml` under `../urdf/simmechanics` since they existed only under `../urdf/ergoCub` and I updated the number of torso_joints from 3 to 2 after removing torso_pitch from conf files.