### PR TITLE
Fix waist_imu_0 reference frame

### DIFF
--- a/urdf/simmechanics/data/ergocub/ERGOCUB_all_options.yaml
+++ b/urdf/simmechanics/data/ergocub/ERGOCUB_all_options.yaml
@@ -1032,7 +1032,7 @@ XMLBlobs:
             <link name="waist_imu_0"/>
     - |  
             <joint name="waist_imu_0_fixed_joint" type="fixed">
-              <origin xyz="0.0354497 0.00639688 0.060600" rpy="-1.5708 0 1.5708"/>
+              <origin xyz="0.0354497 0.00639688 0.060600" rpy="1.5708 0 -1.5708"/>
               <parent link="torso_1"/>
               <child link="waist_imu_0"/>
               <dynamics damping="0.1"/>
@@ -1048,7 +1048,7 @@ XMLBlobs:
             <sensor name="waist_imu_0" type="imu">
             <always_on>1</always_on>
             <update_rate>100</update_rate>
-            <pose>0.0354497 0.00639688 0.060600 -1.5708 0 1.5708</pose>
+            <pose>0.0354497 0.00639688 0.060600 1.5708 0 -1.5708</pose>
             <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
             <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_waist_inertial.ini</yarpConfigurationFile>
             </plugin>
@@ -1057,7 +1057,7 @@ XMLBlobs:
     - |
             <sensor name="waist_imu_0" type="accelerometer">
             <parent link="torso_1"/>
-            <origin rpy="-1.5708 0 1.5708" xyz="0.0354497 0.00639688 0.060600"/>
+            <origin rpy="1.5708 0 -1.5708" xyz="0.0354497 0.00639688 0.060600"/>
             </sensor>
     # upperbody
     - |

--- a/urdf/simmechanics/data/ergocub/ERGOCUB_all_options_gazebo.yaml.in
+++ b/urdf/simmechanics/data/ergocub/ERGOCUB_all_options_gazebo.yaml.in
@@ -1226,7 +1226,7 @@ XMLBlobs:
             <link name="waist_imu_0"/>
     - |
             <joint name="waist_imu_0_fixed_joint" type="fixed">
-              <origin xyz="0.0354497 0.00639688 0.060600" rpy="-1.5708 0 1.5708"/>
+              <origin xyz="0.0354497 0.00639688 0.060600" rpy="1.5708 0 -1.5708"/>
               <parent link="torso_1"/>
               <child link="waist_imu_0"/>
               <dynamics damping="0.1"/>
@@ -1242,7 +1242,7 @@ XMLBlobs:
             <sensor name="waist_imu_0" type="imu">
             <always_on>1</always_on>
             <update_rate>100</update_rate>
-            <pose>0.0354497 0.00639688 0.060600 -1.5708 0 1.5708</pose>
+            <pose>0.0354497 0.00639688 0.060600 1.5708 0 -1.5708</pose>
             <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
             <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_waist_inertial.ini</yarpConfigurationFile>
             </plugin>
@@ -1251,7 +1251,7 @@ XMLBlobs:
     - |
             <sensor name="waist_imu_0" type="accelerometer">
             <parent link="torso_1"/>
-            <origin rpy="-1.5708 0 1.5708" xyz="0.0354497 0.00639688 0.060600"/>
+            <origin rpy="1.5708 0 -1.5708" xyz="0.0354497 0.00639688 0.060600"/>
             </sensor>
     # upperbody
     - |


### PR DESCRIPTION
This PR aims to fix the xsens reference frame mounted on the ergocub waist inside the urdf. 
I read the values streamed by the xsens both real and simulated (on gazebo) and the accelerometer values are coherent. To be sure, the new rf should be plotted in order to see whether it matches with the one on the robot.