### PR TITLE
Fix lidar reference frame

### DIFF
--- a/urdf/simmechanics/data/ergocub/ERGOCUB_all_options.yaml
+++ b/urdf/simmechanics/data/ergocub/ERGOCUB_all_options.yaml
@@ -319,6 +319,7 @@ exportedFrames:
   - frameName: SCSYS_HEAD_S2_LASER
     frameReferenceLink: head
     exportedFrameName: head_laser_frame
+    additionalTransformation: [0,0,0,0,0,-1.5708]
   - frameName: SCSYS_L_SOLE
     frameReferenceLink: l_foot_rear
     exportedFrameName: l_sole
@@ -808,7 +809,7 @@ sensors:
     - |
         <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
             <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_inertial.ini</yarpConfigurationFile>
-        </plugin>     
+        </plugin>
   - sensorName: default
     exportFrameInURDF: No
     sensorType: "depth"
@@ -1030,7 +1031,7 @@ XMLBlobs:
     # imu waist (workaround since simmechanics was not updated)
     - |
             <link name="waist_imu_0"/>
-    - |  
+    - |
             <joint name="waist_imu_0_fixed_joint" type="fixed">
               <origin xyz="0.0354497 0.00639688 0.060600" rpy="1.5708 0 -1.5708"/>
               <parent link="torso_1"/>
@@ -1043,7 +1044,7 @@ XMLBlobs:
               <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_waist_inertial.ini</yarpConfigurationFile>
             </plugin>
             </gazebo>
-    - | 
+    - |
             <gazebo reference="torso_1">
             <sensor name="waist_imu_0" type="imu">
             <always_on>1</always_on>

--- a/urdf/simmechanics/data/ergocub/ERGOCUB_all_options_gazebo.yaml.in
+++ b/urdf/simmechanics/data/ergocub/ERGOCUB_all_options_gazebo.yaml.in
@@ -319,6 +319,7 @@ exportedFrames:
   - frameName: SCSYS_HEAD_S2_LASER
     frameReferenceLink: head
     exportedFrameName: head_laser_frame
+    additionalTransformation: [0,0,0,0,0,-1.5708]
   - frameName: SCSYS_L_SOLE
     frameReferenceLink: l_foot_rear
     exportedFrameName: l_sole
@@ -1237,7 +1238,7 @@ XMLBlobs:
               <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_waist_inertial.ini</yarpConfigurationFile>
             </plugin>
             </gazebo>
-    - | 
+    - |
             <gazebo reference="torso_1">
             <sensor name="waist_imu_0" type="imu">
             <always_on>1</always_on>


### PR DESCRIPTION
It fixes #131 

We fixed the frame of the lidar now the X point ahead as the other frames in the robot

![immagine](https://github.com/icub-tech-iit/ergocub-software/assets/19152494/a5dc5198-bc22-42a8-851f-ec54b87d0263)


We applied the patch on generation side and we didn't fixed the CAD for the issue of creo 9

cc @SimoneMic @pattacini 