### PR TITLE
ergoCubGazeboV1: fix wholebodydynamics

### DIFF
--- a/urdf/simmechanics/data/ergocub/conf/estimators/wbd_ecub_sim.xml
+++ b/urdf/simmechanics/data/ergocub/conf/estimators/wbd_ecub_sim.xml
@@ -61,8 +61,8 @@
                 <!-- ft -->
                 <elem name="left_arm_ft_sensor">ergocub_left_arm_ft</elem>
                 <elem name="right_arm_ft_sensor">ergocub_right_arm_ft</elem>
-                <elem name="left_leg_ft_sensor">left_leg-FT_remapper</elem>
-                <elem name="right_leg_ft_sensor">right_leg-FT_remapper</elem>
+                <elem name="left_leg_ft_sensor">ergocub_left_leg_ft</elem>
+                <elem name="right_leg_ft_sensor">ergocub_right_leg_ft</elem>
             </paramlist>
         </action>
 


### PR DESCRIPTION
This PR should fix wbd with ergoCubGazeboV1 since it didn't start (see https://github.com/icub-tech-iit/ergocub-software/issues/149).
With these changes, instead:

![image](https://github.com/icub-tech-iit/ergocub-software/assets/114698424/757d1478-186f-4e6a-bb76-be0a438f21c9)
