### PR TITLE
Fix ray-related warning printed by sdformat while parsing

### DIFF
--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options.yaml
@@ -936,7 +936,7 @@ sensors:
     - |
         <update_rate>40</update_rate>
     - |
-        <ray name="head_laser_sensor">
+        <ray>
           <scan>
             <horizontal>
               <samples>360</samples>

--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_gazebo.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_gazebo.yaml
@@ -933,7 +933,7 @@ sensors:
     - |
         <update_rate>40</update_rate>
     - |
-        <ray name="head_laser_sensor">
+        <ray>
           <scan>
             <horizontal>
               <samples>360</samples>

--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_minContacts.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_minContacts.yaml
@@ -933,7 +933,7 @@ sensors:
     - |
         <update_rate>40</update_rate>
     - |
-        <ray name="head_laser_sensor">
+        <ray>
           <scan>
             <horizontal>
               <samples>360</samples>

--- a/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options.yaml
@@ -909,7 +909,7 @@ sensors:
     - |
         <update_rate>40</update_rate>
     - |
-        <ray name="head_laser_sensor">
+        <ray>
           <scan>
             <horizontal>
               <samples>360</samples>

--- a/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_gazebo.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_gazebo.yaml
@@ -1126,7 +1126,7 @@ sensors:
     - |
         <update_rate>40</update_rate>
     - |
-        <ray name="head_laser_sensor">
+        <ray>
           <scan>
             <horizontal>
               <samples>360</samples>

--- a/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_minContacts.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_minContacts.yaml
@@ -1239,7 +1239,7 @@ sensors:
     - |
         <update_rate>40</update_rate>
     - |
-        <ray name="head_laser_sensor">
+        <ray>
           <scan>
             <horizontal>
               <samples>360</samples>


### PR DESCRIPTION
While parsing the SDF generated out of the URDF files of ergoCub in Gazebo via sdformat, a warning is printed:
~~~
Warning [parser.cc:833] XML Attribute[name] in element[ray] not defined in SDF, ignoring.
~~~

See https://github.com/ami-iit/rod/issues/26 .

It turns out that we are adding a `name`  attribute to the `ray` element of the sdf, but this attribute is not supported, nor parsed (see http://sdformat.org/spec?ver=1.10&elem=sensor#sensor_ray). The `sensor` element (parent of `ray`) has already a `name` attribute, and that can be used to identify the sensor. I guess this happened as a copy&paste error due to thefact the camera element instead supports an optional name element (see http://sdformat.org/spec?ver=1.10&elem=sensor#sensor_camera), even if to be honest I find it a bit confusing, and probably we can omit it there as well.

To fix the warning, we can just drop the name attribute, that anyhow was not parsed.