### PR TITLE
Modify origin of assigned collisions in simmechanics-generated Gazebo-related models for sole links after sole link frame location was changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed regression in 0.3.4 that moved (in Gazebo-related models) the collision of the sole links to be higher, resulting in the `(r|l)_ankle_2` link being in contact with the ground and resulting in unstable contacts when using the models in Gazebo Classic (https://github.com/icub-tech-iit/ergocub-software/issues/174, https://github.com/icub-tech-iit/ergocub-software/issues/175)
+
 ## [0.3.4] - 2023-08-28
 
 ### urdf

--- a/urdf/simmechanics/CMakeLists.txt
+++ b/urdf/simmechanics/CMakeLists.txt
@@ -123,22 +123,22 @@ macro(generate_ergocub_simmechanics)
     geometricShape:
       shape: box
       size: 0.117 0.100 0.006
-      origin: \"0.0 0.0 0.003 0.0 0.0 0.0\"
+      origin: \"0.0 0.0 -0.0193 0.0 0.0 0.0\"
   - linkName: r_foot_rear
     geometricShape:
       shape: box
       size: 0.117 0.100 0.006
-      origin: \"0.0 0.0 0.003 0.0 0.0 0.0\"
+      origin: \"0.0 0.0 -0.0193 0.0 0.0 0.0\"
   - linkName: l_foot_front
     geometricShape:
       shape: box
       size: 0.117 0.100 0.006
-      origin: \"0.0 0.0 0.003 0.0 0.0 0.0\"
+      origin: \"0.0 0.0 -0.0193 0.0 0.0 0.0\"
   - linkName: l_foot_rear
     geometricShape:
       shape: box
       size: 0.117 0.100 0.006
-      origin: \"0.0 0.0 0.003 0.0 0.0 0.0\"
+      origin: \"0.0 0.0 -0.0193 0.0 0.0 0.0\"
 ")
     endif()
 
@@ -149,22 +149,22 @@ macro(generate_ergocub_simmechanics)
         geometricShape:
           shape: box
           size: 0.117 0.100 0.006
-          origin: \"0.0 0.0 0.003 0.0 0.0 0.0\"
+          origin: \"0.0 0.0 -0.0193 0.0 0.0 0.0\"
       - linkName: r_foot_rear
         geometricShape:
           shape: box
           size: 0.117 0.100 0.006
-          origin: \"0.0 0.0 0.003 0.0 0.0 0.0\"
+          origin: \"0.0 0.0 -0.0193 0.0 0.0 0.0\"
       - linkName: l_foot_front
         geometricShape:
           shape: box
           size: 0.117 0.100 0.006
-          origin: \"0.0 0.0 0.003 0.0 0.0 0.0\"
+          origin: \"0.0 0.0 -0.0193 0.0 0.0 0.0\"
       - linkName: l_foot_rear
         geometricShape:
           shape: box
           size: 0.117 0.100 0.006
-          origin: \"0.0 0.0 0.003 0.0 0.0 0.0\"
+          origin: \"0.0 0.0 -0.0193 0.0 0.0 0.0\"
       - linkName: r_hip_1
         geometricShape:
           shape: box


### PR DESCRIPTION
Fix https://github.com/icub-tech-iit/ergocub-software/issues/174 .

In https://github.com/icub-tech-iit/ergocub-software/pull/158 the location of the frames of the links of the soles ( with names like `(r|l)_foot_(front|back)` ) have been moved to the origin of the FT sensors that connect them with the `(r|l)_ankle_2` link. All the quantities expressed in this frame have been automatically modified to account for its new location by the simmechanics-to-urdf script, except for the location of the assigned collision, that are hardcoded in the .yaml file . This created a regression, has it effectly moved the sole assigned collisions up, so the robot was actually touching the ground with the (r|l)_ankle_2 links, that do not have any contact parameter assigned.

This commit fixes the situation by taking the existing z value of the assigned collision origin, and adding the offset with which the other elements (visual, inertial) have been modified (see https://github.com/icub-tech-iit/ergocub-software/commit/aae9cd689de40f900512fc1ad6a9c0c9b110d02b#diff-4a8f86568a5c3c3a54aa41e5ae088cbcb40bbfd3a63077a9d2c760840494cf1fL239), to obtain:

newCollisionZ = oldCollisionZ + (newVisualZ - oldVisualZ)
              = 0.003         + (0.9335     - 0.9558    )
              = -0.0193