### PR TITLE
ergoCubV1*: fix contacts in the soles

### DIFF
--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_gazebo.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_gazebo.yaml
@@ -964,22 +964,22 @@ assignedCollisionGeometry:
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
     - linkName: r_foot_rear
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
     - linkName: l_foot_front
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
     - linkName: l_foot_rear
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
 
 
 assignedMasses:

--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_minContacts.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_minContacts.yaml
@@ -1163,22 +1163,22 @@ assignedCollisionGeometry:
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
     - linkName: r_foot_rear
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
     - linkName: l_foot_front
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
     - linkName: l_foot_rear
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
     - linkName: r_hip_1
       geometricShape:
         shape: box

--- a/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_gazebo.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_gazebo.yaml
@@ -701,22 +701,22 @@ assignedCollisionGeometry:
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
     - linkName: r_foot_rear
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
     - linkName: l_foot_front
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
     - linkName: l_foot_rear
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
 
 
 assignedMasses:

--- a/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_minContacts.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_minContacts.yaml
@@ -703,22 +703,22 @@ assignedCollisionGeometry:
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
     - linkName: r_foot_rear
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
     - linkName: l_foot_front
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
     - linkName: l_foot_rear
       geometricShape:
         shape: box
         size: [0.117, 0.100, 0.006]
-        origin: [0.0,0.0,0.003,0.0,0.0,0.0]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
     - linkName: r_hip_1
       geometricShape:
         shape: box

--- a/urdf/ergoCub/robots/ergoCubGazeboV1/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubGazeboV1/model.urdf
@@ -266,7 +266,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0.0 0.0 0.003" rpy="0.0 0.0 0.0"/>
+      <origin xyz="0.0 0.0 -0.0193" rpy="0.0 0.0 0.0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>
@@ -301,7 +301,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0.0 0.0 0.003" rpy="0.0 0.0 0.0"/>
+      <origin xyz="0.0 0.0 -0.0193" rpy="0.0 0.0 0.0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>
@@ -558,7 +558,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0.0 0.0 0.003" rpy="0.0 0.0 0.0"/>
+      <origin xyz="0.0 0.0 -0.0193" rpy="0.0 0.0 0.0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>
@@ -586,7 +586,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0.0 0.0 0.003" rpy="0.0 0.0 0.0"/>
+      <origin xyz="0.0 0.0 -0.0193" rpy="0.0 0.0 0.0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>

--- a/urdf/ergoCub/robots/ergoCubGazeboV1_1/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubGazeboV1_1/model.urdf
@@ -1852,7 +1852,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0 0 0.003" rpy="0 -0 0"/>
+      <origin xyz="0 0 -0.0193" rpy="0 -0 0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>
@@ -1879,7 +1879,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0 0 0.003" rpy="0 -0 0"/>
+      <origin xyz="0 0 -0.0193" rpy="0 -0 0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>
@@ -2101,7 +2101,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0 0 0.003" rpy="0 -0 0"/>
+      <origin xyz="0 0 -0.0193" rpy="0 -0 0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>
@@ -2128,7 +2128,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0 0 0.003" rpy="0 -0 0"/>
+      <origin xyz="0 0 -0.0193" rpy="0 -0 0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>

--- a/urdf/ergoCub/robots/ergoCubGazeboV1_1_minContacts/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubGazeboV1_1_minContacts/model.urdf
@@ -1690,7 +1690,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0 0 0.003" rpy="0 -0 0"/>
+      <origin xyz="0 0 -0.0193" rpy="0 -0 0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>
@@ -1717,7 +1717,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0 0 0.003" rpy="0 -0 0"/>
+      <origin xyz="0 0 -0.0193" rpy="0 -0 0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>
@@ -1921,7 +1921,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0 0 0.003" rpy="0 -0 0"/>
+      <origin xyz="0 0 -0.0193" rpy="0 -0 0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>
@@ -1948,7 +1948,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0 0 0.003" rpy="0 -0 0"/>
+      <origin xyz="0 0 -0.0193" rpy="0 -0 0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>

--- a/urdf/ergoCub/robots/ergoCubGazeboV1_minContacts/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubGazeboV1_minContacts/model.urdf
@@ -266,7 +266,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0.0 0.0 0.003" rpy="0.0 0.0 0.0"/>
+      <origin xyz="0.0 0.0 -0.0193" rpy="0.0 0.0 0.0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>
@@ -301,7 +301,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0.0 0.0 0.003" rpy="0.0 0.0 0.0"/>
+      <origin xyz="0.0 0.0 -0.0193" rpy="0.0 0.0 0.0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>
@@ -558,7 +558,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0.0 0.0 0.003" rpy="0.0 0.0 0.0"/>
+      <origin xyz="0.0 0.0 -0.0193" rpy="0.0 0.0 0.0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>
@@ -586,7 +586,7 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0.0 0.0 0.003" rpy="0.0 0.0 0.0"/>
+      <origin xyz="0.0 0.0 -0.0193" rpy="0.0 0.0 0.0"/>
       <geometry>
         <box size="0.117 0.1 0.006"/>
       </geometry>


### PR DESCRIPTION
@traversaro said

Fix https://github.com/icub-tech-iit/ergocub-software/issues/174 .

In https://github.com/icub-tech-iit/ergocub-software/pull/158 the location of the frames of the links of the soles ( with names like `(r|l)_foot_(front|back)` ) have been moved to the origin of the FT sensors that connect them with the `(r|l)_ankle_2` link. All the quantities expressed in this frame have been automatically modified to account for its new location by the simmechanics-to-urdf script, except for the location of the assigned collision, that are hardcoded in the .yaml file . This created a regression, has it effectly moved the sole assigned collisions up, so the robot was actually touching the ground with the (r|l)_ankle_2 links, that do not have any contact parameter assigned.

This commit fixes the situation by taking the existing z value of the assigned collision origin, and adding the offset with which the other elements (visual, inertial) have been modified (see https://github.com/icub-tech-iit/ergocub-software/commit/aae9cd689de40f900512fc1ad6a9c0c9b110d02b#diff-4a8f86568a5c3c3a54aa41e5ae088cbcb40bbfd3a63077a9d2c760840494cf1fL239), to obtain:

newCollisionZ = oldCollisionZ + (newVisualZ - oldVisualZ)
              = 0.003         + (0.9335     - 0.9558    )
              = -0.0193