### PR TITLE
ergoCubSN001: simplify collision shape of feet

### DIFF
--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options.yaml
@@ -704,7 +704,6 @@ exportedFrames:
 
 # Sensors options
 forceTorqueSensors:
-    # upperbody
     - jointName: l_arm_ft_sensor
       directionChildToParent: Yes
       exportFrameInURDF: Yes
@@ -806,49 +805,22 @@ forceTorqueSensors:
 
 
 sensors:
-  - sensorName: default
-    exportFrameInURDF: No
-    sensorType: "accelerometer"
-    updateRate: "100"
-    sensorBlobs:
-    - |
-        <plugin name="ergocub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so" />
-  - sensorName: default
-    exportFrameInURDF: No
-    sensorType: "ray"
-    updateRate: "100"
-    sensorBlobs:
-    - |
-        <plugin name="ergocub_yarp_gazebo_plugin_laser" filename="libgazebo_yarp_lasersensor.so" />
-  - sensorName: default
-    exportFrameInURDF: No
-    sensorType: "gyroscope"
-    updateRate: "100"
   - frameName: SCSYS_HEAD_IMU
     linkName: head
     sensorName: head_imu_0
     exportFrameInURDF: Yes
     sensorType: "accelerometer"
+    updateRate: "100"
     sensorBlobs:
     - |
         <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
             <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_inertial.ini</yarpConfigurationFile>
         </plugin>
-  - sensorName: default
-    exportFrameInURDF: No
-    sensorType: "depth"
-    updateRate: "30"
-  - sensorName: default
-    exportFrameInURDF: No
-    sensorType: "camera"
-    updateRate: "30"
-    sensorBlobs:
-    - |
-        <plugin name="ergocub_yarp_gazebo_plugin_camera" filename="libgazebo_yarp_camera.so" />
   - frameName: SCSYS_HEAD_DEPTH
     linkName: realsense
     sensorName: realsense_head_depth
     sensorType: "depth"
+    updateRate: "30"
     sensorBlobs:
     - |
         <camera name="intel_realsense_depth_camera">
@@ -883,6 +855,7 @@ sensors:
     linkName: realsense
     sensorName: realsense_head_rgb
     sensorType: "camera"
+    updateRate: "30"
     sensorBlobs:
     - |
         <camera name="intel_realsense_rgb_camera">
@@ -919,6 +892,7 @@ sensors:
     sensorName: realsense_imu_0
     exportFrameInURDF: Yes
     sensorType: "accelerometer"
+    updateRate: "100"
     sensorBlobs:
     - |
         <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
@@ -928,6 +902,7 @@ sensors:
     linkName: head
     sensorName: lasersensor_head
     sensorType: "ray"
+    updateRate: "100"
     sensorBlobs:
     - |
         <always_on>1</always_on>
@@ -960,6 +935,29 @@ sensors:
         <plugin name="ergocub_yarp_gazebo_plugin_laser" filename="libgazebo_yarp_lasersensor.so">
           <yarpConfigurationFile>model://ergoCub/conf/sensors/gazebo_ergocub_lidar.ini</yarpConfigurationFile>
         </plugin>
+
+assignedCollisionGeometry:
+    - linkName: r_foot_front
+      geometricShape:
+        shape: box
+        size: [0.117, 0.100, 0.006]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
+    - linkName: r_foot_rear
+      geometricShape:
+        shape: box
+        size: [0.117, 0.100, 0.006]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
+    - linkName: l_foot_front
+      geometricShape:
+        shape: box
+        size: [0.117, 0.100, 0.006]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
+    - linkName: l_foot_rear
+      geometricShape:
+        shape: box
+        size: [0.117, 0.100, 0.006]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
+
 
 assignedMasses:
  torso_1   : 2.0645667

--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_gazebo.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_gazebo.yaml
@@ -700,7 +700,6 @@ exportedFrames:
 
 # Sensors options
 forceTorqueSensors:
-    # upperbody
     - jointName: l_arm_ft_sensor
       directionChildToParent: Yes
       exportFrameInURDF: Yes
@@ -802,50 +801,22 @@ forceTorqueSensors:
 
 
 sensors:
-  - sensorName: default
-    exportFrameInURDF: No
-    sensorType: "accelerometer"
-    updateRate: "100"
-    sensorBlobs:
-    - |
-        <plugin name="ergocub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so" />
-  - sensorName: default
-    exportFrameInURDF: No
-    sensorType: "ray"
-    updateRate: "100"
-    sensorBlobs:
-    - |
-        <plugin name="ergocub_yarp_gazebo_plugin_laser" filename="libgazebo_yarp_lasersensor.so" />
-  - sensorName: default
-    exportFrameInURDF: No
-    sensorType: "gyroscope"
-    updateRate: "100"
   - frameName: SCSYS_HEAD_IMU
     linkName: head
     sensorName: head_imu_0
     exportFrameInURDF: Yes
     sensorType: "accelerometer"
+    updateRate: "100"
     sensorBlobs:
     - |
         <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
             <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_inertial.ini</yarpConfigurationFile>
         </plugin>
-
-  - sensorName: default
-    exportFrameInURDF: No
-    sensorType: "depth"
-    updateRate: "30"
-  - sensorName: default
-    exportFrameInURDF: No
-    sensorType: "camera"
-    updateRate: "30"
-    sensorBlobs:
-    - |
-        <plugin name="ergocub_yarp_gazebo_plugin_camera" filename="libgazebo_yarp_camera.so" />
   - frameName: SCSYS_HEAD_DEPTH
     linkName: realsense
     sensorName: realsense_head_depth
     sensorType: "depth"
+    updateRate: "30"
     sensorBlobs:
     - |
         <camera name="intel_realsense_depth_camera">
@@ -880,6 +851,7 @@ sensors:
     linkName: realsense
     sensorName: realsense_head_rgb
     sensorType: "camera"
+    updateRate: "30"
     sensorBlobs:
     - |
         <camera name="intel_realsense_rgb_camera">
@@ -916,6 +888,7 @@ sensors:
     sensorName: realsense_imu_0
     exportFrameInURDF: Yes
     sensorType: "accelerometer"
+    updateRate: "100"
     sensorBlobs:
     - |
         <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
@@ -925,6 +898,7 @@ sensors:
     linkName: head
     sensorName: lasersensor_head
     sensorType: "ray"
+    updateRate: "100"
     sensorBlobs:
     - |
         <always_on>1</always_on>

--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_minContacts.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_minContacts.yaml
@@ -700,7 +700,6 @@ exportedFrames:
 
 # Sensors options
 forceTorqueSensors:
-    # upperbody
     - jointName: l_arm_ft_sensor
       directionChildToParent: Yes
       exportFrameInURDF: Yes
@@ -802,50 +801,22 @@ forceTorqueSensors:
 
 
 sensors:
-  - sensorName: default
-    exportFrameInURDF: No
-    sensorType: "accelerometer"
-    updateRate: "100"
-    sensorBlobs:
-    - |
-        <plugin name="ergocub_yarp_gazebo_plugin_ACC" filename="libgazebo_yarp_inertial.so" />
-  - sensorName: default
-    exportFrameInURDF: No
-    sensorType: "ray"
-    updateRate: "100"
-    sensorBlobs:
-    - |
-        <plugin name="ergocub_yarp_gazebo_plugin_laser" filename="libgazebo_yarp_lasersensor.so" />
-  - sensorName: default
-    exportFrameInURDF: No
-    sensorType: "gyroscope"
-    updateRate: "100"
   - frameName: SCSYS_HEAD_IMU
     linkName: head
     sensorName: head_imu_0
     exportFrameInURDF: Yes
     sensorType: "accelerometer"
+    updateRate: "100"
     sensorBlobs:
     - |
         <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
             <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_inertial.ini</yarpConfigurationFile>
         </plugin>
-
-  - sensorName: default
-    exportFrameInURDF: No
-    sensorType: "depth"
-    updateRate: "30"
-  - sensorName: default
-    exportFrameInURDF: No
-    sensorType: "camera"
-    updateRate: "30"
-    sensorBlobs:
-    - |
-        <plugin name="ergocub_yarp_gazebo_plugin_camera" filename="libgazebo_yarp_camera.so" />
   - frameName: SCSYS_HEAD_DEPTH
     linkName: realsense
     sensorName: realsense_head_depth
     sensorType: "depth"
+    updateRate: "30"
     sensorBlobs:
     - |
         <camera name="intel_realsense_depth_camera">
@@ -880,6 +851,7 @@ sensors:
     linkName: realsense
     sensorName: realsense_head_rgb
     sensorType: "camera"
+    updateRate: "30"
     sensorBlobs:
     - |
         <camera name="intel_realsense_rgb_camera">
@@ -916,6 +888,7 @@ sensors:
     sensorName: realsense_imu_0
     exportFrameInURDF: Yes
     sensorType: "accelerometer"
+    updateRate: "100"
     sensorBlobs:
     - |
         <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
@@ -925,6 +898,7 @@ sensors:
     linkName: head
     sensorName: lasersensor_head
     sensorType: "ray"
+    updateRate: "100"
     sensorBlobs:
     - |
         <always_on>1</always_on>
@@ -957,7 +931,6 @@ sensors:
         <plugin name="ergocub_yarp_gazebo_plugin_laser" filename="libgazebo_yarp_lasersensor.so">
           <yarpConfigurationFile>model://ergoCub/conf/sensors/gazebo_ergocub_lidar.ini</yarpConfigurationFile>
         </plugin>
-
 
 
 assignedMasses:

--- a/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options.yaml
@@ -934,6 +934,28 @@ sensors:
           <yarpConfigurationFile>model://ergoCub/conf/sensors/gazebo_ergocub_lidar.ini</yarpConfigurationFile>
         </plugin>
 
+assignedCollisionGeometry:
+    - linkName: r_foot_front
+      geometricShape:
+        shape: box
+        size: [0.117, 0.100, 0.006]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
+    - linkName: r_foot_rear
+      geometricShape:
+        shape: box
+        size: [0.117, 0.100, 0.006]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
+    - linkName: l_foot_front
+      geometricShape:
+        shape: box
+        size: [0.117, 0.100, 0.006]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
+    - linkName: l_foot_rear
+      geometricShape:
+        shape: box
+        size: [0.117, 0.100, 0.006]
+        origin: [0.0,0.0,-0.0193,0.0,0.0,0.0]
+
 assignedMasses:
  torso_1   : 2.0645667
 

--- a/urdf/ergoCub/robots/ergoCubSN001/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubSN001/model.urdf
@@ -1241,8 +1241,8 @@
     </collision>
   </link>
   <joint name="l_index_add" type="revolute">
-    <origin xyz="0.022500000000000023 -0.0015000000000006952 -0.0685999999999996" rpy="-8.416895217637947e-16 -0.29670597224465534 5.804755322508926e-17"/>
-    <axis xyz="1.5978340464762954e-11 0.9999999999999999 -3.7677226824487294e-11"/>
+    <origin xyz="0.022500000000000034 -0.0015000000000006397 -0.06859999999999966" rpy="-8.126657451512497e-16 -0.2967059722446555 1.7414265967526777e-16"/>
+    <axis xyz="1.5978451487065422e-11 1.0000000000000002 -3.767719906891169e-11"/>
     <parent link="l_hand_palm"/>
     <child link="l_hand_index_1"/>
     <limit lower="0" upper="0.2617993877991494" effort="1e+9" velocity="1e+9"/>
@@ -1251,8 +1251,8 @@
   <link name="l_hand_index_1">
     <inertial>
       <mass value="0.01923264"/>
-      <origin xyz="0.0046807100979840005 0.0038510231744863237 -0.018526526203731575" rpy="0 -0 0"/>
-      <inertia ixx="2.8516997256950557e-6" ixy="1.4548370851701976e-7" ixz="1.4373172964405972e-7" iyy="2.3676120706829804e-6" iyz="-6.425403568227921e-7" izz="1.4278260577276285e-6"/>
+      <origin xyz="0.0046807100979840005 0.0038510231744862677 -0.018526526203731464" rpy="0 -0 0"/>
+      <inertia ixx="2.8516997256950557e-6" ixy="1.4548370851701976e-7" ixz="1.4373172964405972e-7" iyy="2.3676120706829812e-6" iyz="-6.425403568227921e-7" izz="1.4278260577276285e-6"/>
     </inertial>
     <visual>
       <origin xyz="0 0 0" rpy="0 -0 0"/>
@@ -1571,8 +1571,8 @@
     </collision>
   </link>
   <joint name="l_index_prox" type="revolute">
-    <origin xyz="0.00919253334679343 0 -0.030713451309624218" rpy="-3.0531133177191815e-16 -7.023611484080483e-10 -7.771561172376096e-16"/>
-    <axis xyz="-0.9781476007113543 2.3461557522424743e-11 0.2079116909233844"/>
+    <origin xyz="0.009192533346793416 -2.7755575615628914e-17 -0.030713451309624162" rpy="-2.7755575615628914e-16 -7.023611553469422e-10 -7.771561172376094e-16"/>
+    <axis xyz="-0.9781476007113546 2.346155062839741e-11 0.20791169092338443"/>
     <parent link="l_hand_index_1"/>
     <child link="l_hand_index_2"/>
     <limit lower="0" upper="1.5707963267948966" effort="1e+9" velocity="1e+9"/>
@@ -1604,8 +1604,8 @@
     </collision>
   </link>
   <joint name="l_index_dist" type="revolute">
-    <origin xyz="-1.3877787807814457e-17 -0.001500000000000029 -0.03999999999999987" rpy="-7.482326172536535e-8 1.8041124150158794e-16 -6.106226635438361e-16"/>
-    <axis xyz="-0.9781476007113552 -1.553317034713362e-8 0.20791169092337955"/>
+    <origin xyz="-2.7755575615628914e-17 -0.0014999999999999736 -0.039999999999999925" rpy="-7.482326169760975e-8 1.734723475976807e-16 -6.106226635438361e-16"/>
+    <axis xyz="-0.9781476007113552 -1.5533170287064815e-8 0.2079116909233797"/>
     <parent link="l_hand_index_2"/>
     <child link="l_hand_index_3"/>
     <limit lower="0" upper="1.7994344588061537" effort="1e+9" velocity="1e+9"/>
@@ -1614,8 +1614,8 @@
   <link name="l_hand_index_3">
     <inertial>
       <mass value="0.007251413"/>
-      <origin xyz="-0.018787329483201345 0.0027546711703011484 -0.018853294932697662" rpy="0 -0 0"/>
-      <inertia ixx="1.8961170965705492e-6" ixy="4.65463304290381e-8" ixz="2.5624287052698965e-7" iyy="1.8786285070808614e-6" iyz="-2.891156821380605e-7" izz="4.113501491925148e-7"/>
+      <origin xyz="-0.018787329483201373 0.002754671170301093 -0.018853294932697606" rpy="0 -0 0"/>
+      <inertia ixx="1.8961170965705488e-6" ixy="4.65463304290381e-8" ixz="2.5624287052698965e-7" iyy="1.8786285070808614e-6" iyz="-2.891156821380605e-7" izz="4.113501491925148e-7"/>
     </inertial>
     <visual>
       <origin xyz="0 0 0" rpy="0 -0 0"/>
@@ -1852,13 +1852,10 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0 0 0" rpy="0 -0 0"/>
+      <origin xyz="0 0 -0.0193" rpy="0 -0 0"/>
       <geometry>
-        <mesh filename="package://ergoCub/meshes/simmechanics/sim_ecub_1-1_r_foot_front.stl" scale="0.001 0.001 0.001"/>
+        <box size="0.117 0.1 0.006"/>
       </geometry>
-      <material name="">
-        <color rgba="1 0.51 0 1"/>
-      </material>
     </collision>
   </link>
   <joint name="r_foot_rear_ft_sensor" type="fixed">
@@ -1882,13 +1879,10 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0 0 0" rpy="0 -0 0"/>
+      <origin xyz="0 0 -0.0193" rpy="0 -0 0"/>
       <geometry>
-        <mesh filename="package://ergoCub/meshes/simmechanics/sim_ecub_1-1_r_foot_rear.stl" scale="0.001 0.001 0.001"/>
+        <box size="0.117 0.1 0.006"/>
       </geometry>
-      <material name="">
-        <color rgba="1 0.51 0 1"/>
-      </material>
     </collision>
   </link>
   <joint name="l_hip_roll" type="revolute">
@@ -2107,13 +2101,10 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0 0 0" rpy="0 -0 0"/>
+      <origin xyz="0 0 -0.0193" rpy="0 -0 0"/>
       <geometry>
-        <mesh filename="package://ergoCub/meshes/simmechanics/sim_ecub_1-1_l_foot_front.stl" scale="0.001 0.001 0.001"/>
+        <box size="0.117 0.1 0.006"/>
       </geometry>
-      <material name="">
-        <color rgba="1 0.51 0 1"/>
-      </material>
     </collision>
   </link>
   <joint name="l_foot_rear_ft_sensor" type="fixed">
@@ -2137,13 +2128,10 @@
       </material>
     </visual>
     <collision>
-      <origin xyz="0 0 0" rpy="0 -0 0"/>
+      <origin xyz="0 0 -0.0193" rpy="0 -0 0"/>
       <geometry>
-        <mesh filename="package://ergoCub/meshes/simmechanics/sim_ecub_1-1_l_foot_rear.stl" scale="0.001 0.001 0.001"/>
+        <box size="0.117 0.1 0.006"/>
       </geometry>
-      <material name="">
-        <color rgba="1 0.51 0 1"/>
-      </material>
     </collision>
   </link>
   <link name="head_imu_0"/>


### PR DESCRIPTION
It fixes #179 

Moreover, it removes all the `default` sensors from the ergoCubSN000 yaml, since that clause is not supported by `creo2urdf`