### PR TITLE
ergoCubV1*: correct names l/r_upperarm w/ r/l_upper_arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- ergoCubV1: fixed the names r/l_upperarm with r/l_upper_arm(https://github.com/icub-tech-iit/ergocub-software/issues/197)
 - Fixed HF when resetting the world when using DART as PE(https://github.com/icub-tech-iit/ergocub-software/issues/190)
 
 ## [0.6.0] - 2023-11-15

--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options.yaml
@@ -86,7 +86,7 @@ rename:
     SIM_ECUB_1-0_HEAD_NECK_3--SIM_ECUB_1-0_HEAD: neck_yaw
     SIM_ECUB_1-0_HEAD--SIM_ECUB_1-0_REALSENSE: camera_tilt
     # left forearm
-    SIM_ECUB_1-0_L_UPPERARM: l_upperarm
+    SIM_ECUB_1-0_L_UPPERARM: l_upper_arm
     SIM_ECUB_1-0_L_FOREARM: l_forearm
     SIM_ECUB_1-0_L_WRIST_1: l_wrist_1
     SIM_ECUB_1-0_L_WRIST_2: l_wrist_2
@@ -120,7 +120,7 @@ rename:
     SIM_ECUB_1-0_L_HAND_PALM--SIM_ECUB_1-0_L_HAND_PINKIE_1: l_pinkie_prox
     SIM_ECUB_1-0_L_HAND_PINKIE_1--SIM_ECUB_1-0_L_HAND_PINKIE_2: l_pinkie_dist
     # right forearm
-    SIM_ECUB_1-0_R_UPPERARM: r_upperarm
+    SIM_ECUB_1-0_R_UPPERARM: r_upper_arm
     SIM_ECUB_1-0_R_FOREARM: r_forearm
     SIM_ECUB_1-0_R_WRIST_1: r_wrist_1
     SIM_ECUB_1-0_R_WRIST_2: r_wrist_2
@@ -235,7 +235,7 @@ linkFrames:
   - linkName: realsense
     frameName: SCSYS_REALSENSE
   # left forearm
-  - linkName: l_upperarm
+  - linkName: l_upper_arm
     frameName: SCSYS_L_UPPERARM
   - linkName: l_forearm
     frameName: SCSYS_L_FOREARM
@@ -270,7 +270,7 @@ linkFrames:
   - linkName: l_hand_pinkie_2
     frameName: SCSYS_L_HAND_PINKIE_DIST # WRONG NAME
     # right forearm
-  - linkName: r_upperarm
+  - linkName: r_upper_arm
     frameName: SCSYS_R_UPPERARM
   - linkName: r_forearm
     frameName: SCSYS_R_FOREARM

--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_gazebo.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_gazebo.yaml
@@ -86,7 +86,7 @@ rename:
     SIM_ECUB_1-0_HEAD_NECK_3--SIM_ECUB_1-0_HEAD: neck_yaw
     SIM_ECUB_1-0_HEAD--SIM_ECUB_1-0_REALSENSE: camera_tilt
     # left forearm
-    SIM_ECUB_1-0_L_UPPERARM: l_upperarm
+    SIM_ECUB_1-0_L_UPPERARM: l_upper_arm
     SIM_ECUB_1-0_L_FOREARM: l_forearm
     SIM_ECUB_1-0_L_WRIST_1: l_wrist_1
     SIM_ECUB_1-0_L_WRIST_2: l_wrist_2
@@ -120,7 +120,7 @@ rename:
     SIM_ECUB_1-0_L_HAND_PALM--SIM_ECUB_1-0_L_HAND_PINKIE_1: l_pinkie_prox
     SIM_ECUB_1-0_L_HAND_PINKIE_1--SIM_ECUB_1-0_L_HAND_PINKIE_2: l_pinkie_dist
     # right forearm
-    SIM_ECUB_1-0_R_UPPERARM: r_upperarm
+    SIM_ECUB_1-0_R_UPPERARM: r_upper_arm
     SIM_ECUB_1-0_R_FOREARM: r_forearm
     SIM_ECUB_1-0_R_WRIST_1: r_wrist_1
     SIM_ECUB_1-0_R_WRIST_2: r_wrist_2
@@ -235,7 +235,7 @@ linkFrames:
   - linkName: realsense
     frameName: SCSYS_REALSENSE
   # left forearm
-  - linkName: l_upperarm
+  - linkName: l_upper_arm
     frameName: SCSYS_L_UPPERARM
   - linkName: l_forearm
     frameName: SCSYS_L_FOREARM
@@ -270,7 +270,7 @@ linkFrames:
   - linkName: l_hand_pinkie_2
     frameName: SCSYS_L_HAND_PINKIE_DIST # WRONG NAME
     # right forearm
-  - linkName: r_upperarm
+  - linkName: r_upper_arm
     frameName: SCSYS_R_UPPERARM
   - linkName: r_forearm
     frameName: SCSYS_R_FOREARM

--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_minContacts.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_minContacts.yaml
@@ -86,7 +86,7 @@ rename:
     SIM_ECUB_1-0_HEAD_NECK_3--SIM_ECUB_1-0_HEAD: neck_yaw
     SIM_ECUB_1-0_HEAD--SIM_ECUB_1-0_REALSENSE: camera_tilt
     # left forearm
-    SIM_ECUB_1-0_L_UPPERARM: l_upperarm
+    SIM_ECUB_1-0_L_UPPERARM: l_upper_arm
     SIM_ECUB_1-0_L_FOREARM: l_forearm
     SIM_ECUB_1-0_L_WRIST_1: l_wrist_1
     SIM_ECUB_1-0_L_WRIST_2: l_wrist_2
@@ -120,7 +120,7 @@ rename:
     SIM_ECUB_1-0_L_HAND_PALM--SIM_ECUB_1-0_L_HAND_PINKIE_1: l_pinkie_prox
     SIM_ECUB_1-0_L_HAND_PINKIE_1--SIM_ECUB_1-0_L_HAND_PINKIE_2: l_pinkie_dist
     # right forearm
-    SIM_ECUB_1-0_R_UPPERARM: r_upperarm
+    SIM_ECUB_1-0_R_UPPERARM: r_upper_arm
     SIM_ECUB_1-0_R_FOREARM: r_forearm
     SIM_ECUB_1-0_R_WRIST_1: r_wrist_1
     SIM_ECUB_1-0_R_WRIST_2: r_wrist_2
@@ -235,7 +235,7 @@ linkFrames:
   - linkName: realsense
     frameName: SCSYS_REALSENSE
   # left forearm
-  - linkName: l_upperarm
+  - linkName: l_upper_arm
     frameName: SCSYS_L_UPPERARM
   - linkName: l_forearm
     frameName: SCSYS_L_FOREARM
@@ -270,7 +270,7 @@ linkFrames:
   - linkName: l_hand_pinkie_2
     frameName: SCSYS_L_HAND_PINKIE_DIST # WRONG NAME
     # right forearm
-  - linkName: r_upperarm
+  - linkName: r_upper_arm
     frameName: SCSYS_R_UPPERARM
   - linkName: r_forearm
     frameName: SCSYS_R_FOREARM
@@ -1267,7 +1267,7 @@ assignedCollisionGeometry:
         shape: box
         size: [0.0,0.0,0.0]
         origin: [0.0,0.0,0.0,0.0,0.0,0.0]
-    - linkName: r_upperarm
+    - linkName: r_upper_arm
       geometricShape:
         shape: box
         size: [0.0,0.0,0.0]
@@ -1367,7 +1367,7 @@ assignedCollisionGeometry:
         shape: box
         size: [0.0,0.0,0.0]
         origin: [0.0,0.0,0.0,0.0,0.0,0.0]
-    - linkName: l_upperarm
+    - linkName: l_upper_arm
       geometricShape:
         shape: box
         size: [0.0,0.0,0.0]

--- a/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options.yaml
@@ -86,7 +86,7 @@ rename:
     SIM_ECUB_1-1_HEAD_NECK_3--SIM_ECUB_1-1_HEAD: neck_yaw
     SIM_ECUB_1-1_HEAD--SIM_ECUB_1-1_REALSENSE: camera_tilt
     # left forearm
-    SIM_ECUB_1-1_L_UPPERARM: l_upperarm
+    SIM_ECUB_1-1_L_UPPERARM: l_upper_arm
     SIM_ECUB_1-1_L_FOREARM: l_forearm
     SIM_ECUB_1-1_L_WRIST_1: l_wrist_1
     SIM_ECUB_1-1_L_WRIST_2: l_wrist_2
@@ -120,7 +120,7 @@ rename:
     SIM_ECUB_1-1_L_HAND_PALM--SIM_ECUB_1-1_L_HAND_PINKIE_1: l_pinkie_prox
     SIM_ECUB_1-1_L_HAND_PINKIE_1--SIM_ECUB_1-1_L_HAND_PINKIE_2: l_pinkie_dist
     # right forearm
-    SIM_ECUB_1-1_R_UPPERARM: r_upperarm
+    SIM_ECUB_1-1_R_UPPERARM: r_upper_arm
     SIM_ECUB_1-1_R_FOREARM: r_forearm
     SIM_ECUB_1-1_R_WRIST_1: r_wrist_1
     SIM_ECUB_1-1_R_WRIST_2: r_wrist_2
@@ -234,7 +234,7 @@ linkFrames:
   - linkName: realsense
     frameName: SCSYS_REALSENSE
   # left forearm
-  - linkName: l_upperarm
+  - linkName: l_upper_arm
     frameName: SCSYS_L_UPPERARM
   - linkName: l_forearm
     frameName: SCSYS_L_FOREARM
@@ -269,7 +269,7 @@ linkFrames:
   - linkName: l_hand_pinkie_2
     frameName: SCSYS_L_HAND_PINKIE_2
     # right forearm
-  - linkName: r_upperarm
+  - linkName: r_upper_arm
     frameName: SCSYS_R_UPPERARM
   - linkName: r_forearm
     frameName: SCSYS_R_FOREARM

--- a/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_gazebo.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_gazebo.yaml
@@ -86,7 +86,7 @@ rename:
     SIM_ECUB_1-1_HEAD_NECK_3--SIM_ECUB_1-1_HEAD: neck_yaw
     SIM_ECUB_1-1_HEAD--SIM_ECUB_1-1_REALSENSE: camera_tilt
     # left forearm
-    SIM_ECUB_1-1_L_UPPERARM: l_upperarm
+    SIM_ECUB_1-1_L_UPPERARM: l_upper_arm
     SIM_ECUB_1-1_L_FOREARM: l_forearm
     SIM_ECUB_1-1_L_WRIST_1: l_wrist_1
     SIM_ECUB_1-1_L_WRIST_2: l_wrist_2
@@ -120,7 +120,7 @@ rename:
     SIM_ECUB_1-1_L_HAND_PALM--SIM_ECUB_1-1_L_HAND_PINKIE_1: l_pinkie_prox
     SIM_ECUB_1-1_L_HAND_PINKIE_1--SIM_ECUB_1-1_L_HAND_PINKIE_2: l_pinkie_dist
     # right forearm
-    SIM_ECUB_1-1_R_UPPERARM: r_upperarm
+    SIM_ECUB_1-1_R_UPPERARM: r_upper_arm
     SIM_ECUB_1-1_R_FOREARM: r_forearm
     SIM_ECUB_1-1_R_WRIST_1: r_wrist_1
     SIM_ECUB_1-1_R_WRIST_2: r_wrist_2
@@ -234,7 +234,7 @@ linkFrames:
   - linkName: realsense
     frameName: SCSYS_REALSENSE
   # left forearm
-  - linkName: l_upperarm
+  - linkName: l_upper_arm
     frameName: SCSYS_L_UPPERARM
   - linkName: l_forearm
     frameName: SCSYS_L_FOREARM
@@ -269,7 +269,7 @@ linkFrames:
   - linkName: l_hand_pinkie_2
     frameName: SCSYS_L_HAND_PINKIE_2
     # right forearm
-  - linkName: r_upperarm
+  - linkName: r_upper_arm
     frameName: SCSYS_R_UPPERARM
   - linkName: r_forearm
     frameName: SCSYS_R_FOREARM

--- a/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_minContacts.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_minContacts.yaml
@@ -86,7 +86,7 @@ rename:
     SIM_ECUB_1-1_HEAD_NECK_3--SIM_ECUB_1-1_HEAD: neck_yaw
     SIM_ECUB_1-1_HEAD--SIM_ECUB_1-1_REALSENSE: camera_tilt
     # left forearm
-    SIM_ECUB_1-1_L_UPPERARM: l_upperarm
+    SIM_ECUB_1-1_L_UPPERARM: l_upper_arm
     SIM_ECUB_1-1_L_FOREARM: l_forearm
     SIM_ECUB_1-1_L_WRIST_1: l_wrist_1
     SIM_ECUB_1-1_L_WRIST_2: l_wrist_2
@@ -120,7 +120,7 @@ rename:
     SIM_ECUB_1-1_L_HAND_PALM--SIM_ECUB_1-1_L_HAND_PINKIE_1: l_pinkie_prox
     SIM_ECUB_1-1_L_HAND_PINKIE_1--SIM_ECUB_1-1_L_HAND_PINKIE_2: l_pinkie_dist
     # right forearm
-    SIM_ECUB_1-1_R_UPPERARM: r_upperarm
+    SIM_ECUB_1-1_R_UPPERARM: r_upper_arm
     SIM_ECUB_1-1_R_FOREARM: r_forearm
     SIM_ECUB_1-1_R_WRIST_1: r_wrist_1
     SIM_ECUB_1-1_R_WRIST_2: r_wrist_2
@@ -234,7 +234,7 @@ linkFrames:
   - linkName: realsense
     frameName: SCSYS_REALSENSE
   # left forearm
-  - linkName: l_upperarm
+  - linkName: l_upper_arm
     frameName: SCSYS_L_UPPERARM
   - linkName: l_forearm
     frameName: SCSYS_L_FOREARM
@@ -269,7 +269,7 @@ linkFrames:
   - linkName: l_hand_pinkie_2
     frameName: SCSYS_L_HAND_PINKIE_2
     # right forearm
-  - linkName: r_upperarm
+  - linkName: r_upper_arm
     frameName: SCSYS_R_UPPERARM
   - linkName: r_forearm
     frameName: SCSYS_R_FOREARM
@@ -834,7 +834,7 @@ assignedCollisionGeometry:
         shape: box
         size: [0.0,0.0,0.0]
         origin: [0.0,0.0,0.0,0.0,0.0,0.0]
-    - linkName: r_upperarm
+    - linkName: r_upper_arm
       geometricShape:
         shape: box
         size: [0.0,0.0,0.0]
@@ -934,7 +934,7 @@ assignedCollisionGeometry:
         shape: box
         size: [0.0,0.0,0.0]
         origin: [0.0,0.0,0.0,0.0,0.0,0.0]
-    - linkName: l_upperarm
+    - linkName: l_upper_arm
       geometricShape:
         shape: box
         size: [0.0,0.0,0.0]

--- a/urdf/ergoCub/robots/ergoCubGazeboV1/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubGazeboV1/model.urdf
@@ -938,7 +938,7 @@
     <child link="r_shoulder_3"/>
     <dynamics damping="0.1"/>
   </joint>
-  <link name="r_upperarm">
+  <link name="r_upper_arm">
     <inertial>
       <origin xyz="0.00014706365601642457 -0.002335316124503606 -0.050116658948294965" rpy="0.12008559189031787 -0.2297881760318691 1.288278055899408"/>
       <mass value="1.77224"/>
@@ -964,7 +964,7 @@
     <origin xyz="0 0 -0.02250022557998886" rpy="0 0 0"/>
     <axis xyz="1.7133815359560156e-07 -2.3659291614741562e-07 0.999999570574365"/>
     <parent link="r_shoulder_3"/>
-    <child link="r_upperarm"/>
+    <child link="r_upper_arm"/>
     <limit effort="50000" lower="-0.8726646259971648" upper="1.3962634015954636" velocity="120.0"/>
     <dynamics damping="2.0" friction="0.0"/>
   </joint>
@@ -993,7 +993,7 @@
   <joint name="r_elbow" type="revolute">
     <origin xyz="0.010000044612835832 0.0015000724494400042 -0.1236996308912752" rpy="0 0 0"/>
     <axis xyz="3.352246002574083e-07 -0.9999999783534191 2.2068612626213735e-07"/>
-    <parent link="r_upperarm"/>
+    <parent link="r_upper_arm"/>
     <child link="r_forearm"/>
     <limit effort="50000" lower="-0.05235987755982989" upper="1.3089969389957472" velocity="120.0"/>
     <dynamics damping="2.0" friction="0.0"/>
@@ -1963,7 +1963,7 @@
     <child link="l_shoulder_3"/>
     <dynamics damping="0.1"/>
   </joint>
-  <link name="l_upperarm">
+  <link name="l_upper_arm">
     <inertial>
       <origin xyz="0.00013045033120965763 0.0022533114588239866 -0.05006471572755227" rpy="0.12008501986317731 0.2297882840735942 1.8533146530335884"/>
       <mass value="1.77085"/>
@@ -1989,7 +1989,7 @@
     <origin xyz="0 0 -0.022500225580001282" rpy="0 0 0"/>
     <axis xyz="3.936910710766739e-07 -1.8507626386998766e-07 -0.9999995705743131"/>
     <parent link="l_shoulder_3"/>
-    <child link="l_upperarm"/>
+    <child link="l_upper_arm"/>
     <limit effort="50000" lower="-0.8726646259971648" upper="1.3962634015954636" velocity="120.0"/>
     <dynamics damping="2.0" friction="0.0"/>
   </joint>
@@ -2018,7 +2018,7 @@
   <joint name="l_elbow" type="revolute">
     <origin xyz="0.01000011478523053 -0.001500064220488484 -0.12369962531821438" rpy="0 0 0"/>
     <axis xyz="-1.4958988243767013e-07 -0.9999999783534517 -2.7220291587415346e-07"/>
-    <parent link="l_upperarm"/>
+    <parent link="l_upper_arm"/>
     <child link="l_forearm"/>
     <limit effort="50000" lower="-0.05235987755982989" upper="1.3089969389957472" velocity="120.0"/>
     <dynamics damping="2.0" friction="0.0"/>

--- a/urdf/ergoCub/robots/ergoCubGazeboV1_minContacts/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubGazeboV1_minContacts/model.urdf
@@ -938,7 +938,7 @@
     <child link="r_shoulder_3"/>
     <dynamics damping="0.1"/>
   </joint>
-  <link name="r_upperarm">
+  <link name="r_upper_arm">
     <inertial>
       <origin xyz="0.00014706365601642457 -0.002335316124503606 -0.050116658948294965" rpy="0.12008559189031787 -0.2297881760318691 1.288278055899408"/>
       <mass value="1.77224"/>
@@ -964,7 +964,7 @@
     <origin xyz="0 0 -0.02250022557998886" rpy="0 0 0"/>
     <axis xyz="1.7133815359560156e-07 -2.3659291614741562e-07 0.999999570574365"/>
     <parent link="r_shoulder_3"/>
-    <child link="r_upperarm"/>
+    <child link="r_upper_arm"/>
     <limit effort="50000" lower="-0.8726646259971648" upper="1.3962634015954636" velocity="120.0"/>
     <dynamics damping="2.0" friction="0.0"/>
   </joint>
@@ -993,7 +993,7 @@
   <joint name="r_elbow" type="revolute">
     <origin xyz="0.010000044612835832 0.0015000724494400042 -0.1236996308912752" rpy="0 0 0"/>
     <axis xyz="3.352246002574083e-07 -0.9999999783534191 2.2068612626213735e-07"/>
-    <parent link="r_upperarm"/>
+    <parent link="r_upper_arm"/>
     <child link="r_forearm"/>
     <limit effort="50000" lower="-0.05235987755982989" upper="1.3089969389957472" velocity="120.0"/>
     <dynamics damping="2.0" friction="0.0"/>
@@ -1963,7 +1963,7 @@
     <child link="l_shoulder_3"/>
     <dynamics damping="0.1"/>
   </joint>
-  <link name="l_upperarm">
+  <link name="l_upper_arm">
     <inertial>
       <origin xyz="0.00013045033120965763 0.0022533114588239866 -0.05006471572755227" rpy="0.12008501986317731 0.2297882840735942 1.8533146530335884"/>
       <mass value="1.77085"/>
@@ -1989,7 +1989,7 @@
     <origin xyz="0 0 -0.022500225580001282" rpy="0 0 0"/>
     <axis xyz="3.936910710766739e-07 -1.8507626386998766e-07 -0.9999995705743131"/>
     <parent link="l_shoulder_3"/>
-    <child link="l_upperarm"/>
+    <child link="l_upper_arm"/>
     <limit effort="50000" lower="-0.8726646259971648" upper="1.3962634015954636" velocity="120.0"/>
     <dynamics damping="2.0" friction="0.0"/>
   </joint>
@@ -2018,7 +2018,7 @@
   <joint name="l_elbow" type="revolute">
     <origin xyz="0.01000011478523053 -0.001500064220488484 -0.12369962531821438" rpy="0 0 0"/>
     <axis xyz="-1.4958988243767013e-07 -0.9999999783534517 -2.7220291587415346e-07"/>
-    <parent link="l_upperarm"/>
+    <parent link="l_upper_arm"/>
     <child link="l_forearm"/>
     <limit effort="50000" lower="-0.05235987755982989" upper="1.3089969389957472" velocity="120.0"/>
     <dynamics damping="2.0" friction="0.0"/>

--- a/urdf/ergoCub/robots/ergoCubSN000/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubSN000/model.urdf
@@ -938,7 +938,7 @@
     <child link="r_shoulder_3"/>
     <dynamics damping="0.1"/>
   </joint>
-  <link name="r_upperarm">
+  <link name="r_upper_arm">
     <inertial>
       <origin xyz="0.00014706365601642457 -0.002335316124503606 -0.050116658948294965" rpy="0.12008559189031787 -0.2297881760318691 1.288278055899408"/>
       <mass value="1.77224"/>
@@ -964,7 +964,7 @@
     <origin xyz="0 0 -0.02250022557998886" rpy="0 0 0"/>
     <axis xyz="1.7133815359560156e-07 -2.3659291614741562e-07 0.999999570574365"/>
     <parent link="r_shoulder_3"/>
-    <child link="r_upperarm"/>
+    <child link="r_upper_arm"/>
     <limit effort="50000" lower="-0.8726646259971648" upper="1.3962634015954636" velocity="120.0"/>
     <dynamics damping="2.0" friction="0.0"/>
   </joint>
@@ -993,7 +993,7 @@
   <joint name="r_elbow" type="revolute">
     <origin xyz="0.010000044612835832 0.0015000724494400042 -0.1236996308912752" rpy="0 0 0"/>
     <axis xyz="3.352246002574083e-07 -0.9999999783534191 2.2068612626213735e-07"/>
-    <parent link="r_upperarm"/>
+    <parent link="r_upper_arm"/>
     <child link="r_forearm"/>
     <limit effort="50000" lower="-0.05235987755982989" upper="1.3089969389957472" velocity="120.0"/>
     <dynamics damping="2.0" friction="0.0"/>
@@ -1963,7 +1963,7 @@
     <child link="l_shoulder_3"/>
     <dynamics damping="0.1"/>
   </joint>
-  <link name="l_upperarm">
+  <link name="l_upper_arm">
     <inertial>
       <origin xyz="0.00013045033120965763 0.0022533114588239866 -0.05006471572755227" rpy="0.12008501986317731 0.2297882840735942 1.8533146530335884"/>
       <mass value="1.77085"/>
@@ -1989,7 +1989,7 @@
     <origin xyz="0 0 -0.022500225580001282" rpy="0 0 0"/>
     <axis xyz="3.936910710766739e-07 -1.8507626386998766e-07 -0.9999995705743131"/>
     <parent link="l_shoulder_3"/>
-    <child link="l_upperarm"/>
+    <child link="l_upper_arm"/>
     <limit effort="50000" lower="-0.8726646259971648" upper="1.3962634015954636" velocity="120.0"/>
     <dynamics damping="2.0" friction="0.0"/>
   </joint>
@@ -2018,7 +2018,7 @@
   <joint name="l_elbow" type="revolute">
     <origin xyz="0.01000011478523053 -0.001500064220488484 -0.12369962531821438" rpy="0 0 0"/>
     <axis xyz="-1.4958988243767013e-07 -0.9999999783534517 -2.7220291587415346e-07"/>
-    <parent link="l_upperarm"/>
+    <parent link="l_upper_arm"/>
     <child link="l_forearm"/>
     <limit effort="50000" lower="-0.05235987755982989" upper="1.3089969389957472" velocity="120.0"/>
     <dynamics damping="2.0" friction="0.0"/>


### PR DESCRIPTION
It fixes #197

The strange thing it was that also in the V1.1 yaml there were `r/l_upperarm`