### PR TITLE
Fix ergoCubEmotions installation dir

### DIFF
--- a/app/ergoCubEmotions/CMakeLists.txt
+++ b/app/ergoCubEmotions/CMakeLists.txt
@@ -4,5 +4,5 @@
 # This software may be modified and distributed under the terms of the
 # BSD-3-Clause license. See the accompanying LICENSE file for details.
 
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/conf/config.ini DESTINATION ${YARP_CONTEXTS_INSTALL_DIR}/${PROJECT_NAME})
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/scripts/emotionHandler.xml DESTINATION ${YARP_APPLICATIONS_INSTALL_DIR}/${PROJECT_NAME})
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/conf/config.ini DESTINATION ${YARP_CONTEXTS_INSTALL_DIR}/ergoCubEmotions)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/scripts/emotionHandler.xml DESTINATION ${YARP_APPLICATIONS_INSTALL_DIR}/ergoCubEmotions)


### PR DESCRIPTION
@S-Dafarra pointed out that `ergoCubEmotions` configuration files were not installed in the same directory after https://github.com/icub-tech-iit/ergocub-software/pull/196. This fixes the error and makes the expressions run properly (tested locally on ergoCub) 

cc @GiulioRomualdi 