### PR TITLE
Avoid pushing gh-pages when creating a PR

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -58,6 +58,7 @@ jobs:
           mv doc/mkdocs/site/* ./
 
       - name: Commit and push
+        if: github.event_name == 'push'
         run: |
           git add .
           git commit -m "Publish site"


### PR DESCRIPTION
As per title, the gh-pages push will be done only once merged