### PR TITLE
ergoCubEmotions: avoid reading videos at each update of the module

### DIFF
--- a/app/ergoCubEmotions/conf/config.ini
+++ b/app/ergoCubEmotions/conf/config.ini
@@ -2,30 +2,25 @@
 num_expressions 4
 num_transitions 12
 
-# [expression_0]
-# name neutral
-# type image
-# file expressions/images/exp_img_0.png
-
-# [expression_1]
-# name happy
-# type image
-# file expressions/images/exp_img_1.png
-
-# [expression_2]
-# name alert
-# type image
-# file expressions/images/exp_img_2.png
-
-# [expression_3]
-# name shy
-# type image
-# file expressions/images/exp_img_3.png
-
-# [expression_4]
-# name wink
-# type video
-# file expressions/videos/exp_vid_0.mp4
+#[expression_0]
+#name neutral
+#type image
+#file expressions/images/exp_img_0.png
+#
+#[expression_1]
+#name happy
+#type image
+#file expressions/images/exp_img_1.png
+#
+#[expression_2]
+#name alert
+#type image
+#file expressions/images/exp_img_2.png
+#
+#[expression_3]
+#name shy
+#type image
+#file expressions/images/exp_img_3.png
 
 [expression_0]
 name neutral

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
@@ -57,6 +57,13 @@ bool ErgoCubEmotions::configure(ResourceFinder& rf)
 
         std::pair<std::string, std::string> par = std::make_pair(type, filePath);
         imgMap[name] = par;
+
+        if(!(std::count(videoFileNames.begin(), videoFileNames.end(), filePath)))
+        {
+            videoFileNames.push_back(filePath);
+            VideoCapture cap(filePath);
+            videoCaptures.push_back(cap);
+        }
     }
 
     for(int j = 0; j < nTransitions; j++)
@@ -88,6 +95,13 @@ bool ErgoCubEmotions::configure(ResourceFinder& rf)
         std::string filePath = rf.findFile(file);
         std::pair<std::string, std::string> par = std::make_pair(source, destination);
         transitionMap[par] = filePath;
+
+        if(!(std::count(videoFileNames.begin(), videoFileNames.end(), filePath)))
+        {
+            videoFileNames.push_back(filePath);
+            VideoCapture cap(filePath);
+            videoCaptures.push_back(cap);
+        }
     }
 
     isTransition = true;
@@ -159,7 +173,16 @@ bool ErgoCubEmotions::updateModule()
         {
             showTransition(current_local, command_local);
         }
-        VideoCapture cap(info.second);
+
+        VideoCapture cap;
+        for (size_t i = 0; i < videoFileNames.size(); i++)
+        {
+            if(info.second == videoFileNames[i])
+            {
+                cap = videoCaptures.at(i);
+            }
+        }
+        
         Mat frame;
 
         while(cap.isOpened())
@@ -205,7 +228,14 @@ void ErgoCubEmotions::showTransition(const std::string& current, const std::stri
     {
         if(k->first.first == current && k->first.second == desired)
         {
-            VideoCapture capTrans(k->second);
+            VideoCapture capTrans;
+            for (size_t i = 0; i < videoFileNames.size(); i++)
+            {
+                if(k->second == videoFileNames[i])
+                {
+                    capTrans = videoCaptures.at(i);
+                }
+            }
             Mat frameTrans;
 
             while(capTrans.isOpened())

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
@@ -195,6 +195,7 @@ bool ErgoCubEmotions::updateModule()
             imshow("emotion", frame);
             pollKey();
         }
+        cap.release();
     }
 
     return true;
@@ -233,7 +234,7 @@ void ErgoCubEmotions::showTransition(const std::string& current, const std::stri
             {
                 if(k->second == videoFileNames[i])
                 {
-                    capTrans = videoCaptures.at(i);
+                    capTrans.open(videoFileNames[i]);
                 }
             }
             Mat frameTrans;

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
@@ -99,8 +99,6 @@ bool ErgoCubEmotions::configure(ResourceFinder& rf)
         if(!(std::count(videoFileNames.begin(), videoFileNames.end(), filePath)))
         {
             videoFileNames.push_back(filePath);
-            VideoCapture cap(filePath);
-            videoCaptures.push_back(cap);
         }
     }
 

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.h
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.h
@@ -49,6 +49,8 @@ class ErgoCubEmotions : public yarp::os::RFModule, public ergoCubEmotions_IDL {
         std::vector<std::string> avlEmotions;
         cv::Mat img;
         std::mutex mutex;
+        std::vector<cv::VideoCapture> videoCaptures;
+        std::vector<std::string> videoFileNames;
 };
 
 #endif


### PR DESCRIPTION
This should fix https://github.com/icub-tech-iit/ergocub-software/issues/213. I tried to launch the module after these changes on my laptop and the cpu consumption significantly decreased. 

To be tested on `ergocub-head`.