### PR TITLE
ergoCubSN001/GazeboV1_1*: add ft imu via `sensor`

### DIFF
--- a/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options.yaml
@@ -933,7 +933,50 @@ sensors:
         <plugin name="ergocub_yarp_gazebo_plugin_laser" filename="libgazebo_yarp_lasersensor.so">
           <yarpConfigurationFile>model://ergoCub/conf/sensors/gazebo_ergocub_lidar.ini</yarpConfigurationFile>
         </plugin>
-
+  - frameName: SCSYS_L_ANKLE_2_FT_FRONT
+    linkName: l_foot_front
+    sensorName: l_foot_front_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_L_ANKLE_2_FT_REAR
+    linkName: l_foot_rear
+    sensorName: l_foot_rear_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_R_ANKLE_2_FT_FRONT
+    linkName: r_foot_front
+    sensorName: r_foot_front_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_R_ANKLE_2_FT_REAR
+    linkName: r_foot_rear
+    sensorName: r_foot_rear_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
 assignedCollisionGeometry:
     - linkName: r_foot_front
       geometricShape:
@@ -1051,74 +1094,6 @@ reverseRotationAxis:
     r_pinkie_prox
 
 XMLBlobs:
-    # left foot IMU (front)
-    - |
-            <gazebo reference="l_ankle_2">
-              <sensor name="l_foot_front_ft_imu" type="imu">
-                <always_on>1</always_on>
-                <update_rate>100</update_rate>
-                <pose>0.13525 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
-                </plugin>
-              </sensor>
-            </gazebo>
-    - |
-            <sensor name="l_foot_front_ft_imu" type="accelerometer">
-              <parent link="l_ankle_2" />
-              <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.13525 0 -0.07019999999999993" />
-            </sensor>
-    # left foot IMU (rear)
-    - |
-            <gazebo reference="l_ankle_2">
-              <sensor name="l_foot_rear_ft_imu" type="imu">
-                <always_on>1</always_on>
-                <update_rate>100</update_rate>
-                <pose>0.016000000000000004 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
-                </plugin>
-              </sensor>
-            </gazebo>
-    - |
-            <sensor name="l_foot_rear_ft_imu" type="accelerometer">
-              <parent link="l_ankle_2" />
-              <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
-            </sensor>
-    # right foot IMU (front)
-    - |
-            <gazebo reference="r_ankle_2">
-              <sensor name="r_foot_front_ft_imu" type="imu">
-                <always_on>1</always_on>
-                <update_rate>100</update_rate>
-                <pose>0.13525 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
-                </plugin>
-              </sensor>
-            </gazebo>
-    - |
-            <sensor name="r_foot_front_ft_imu" type="accelerometer">
-              <parent link="r_ankle_2" />
-              <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.13525 0 -0.07019999999999993" />
-            </sensor>
-    # right foot IMU (rear)
-    - |
-            <gazebo reference="r_ankle_2">
-              <sensor name="r_foot_rear_ft_imu" type="imu">
-                <always_on>1</always_on>
-                <update_rate>100</update_rate>
-                <pose>0.016000000000000004 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
-                </plugin>
-              </sensor>
-            </gazebo>
-    - |
-            <sensor name="r_foot_rear_ft_imu" type="accelerometer">
-              <parent link="r_ankle_2" />
-              <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
-            </sensor>
     # imu waist (workaround since simmechanics was not updated)
     - |
             <link name="waist_imu_0"/>

--- a/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_gazebo.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_gazebo.yaml
@@ -1150,6 +1150,50 @@ sensors:
         <plugin name="ergocub_yarp_gazebo_plugin_laser" filename="libgazebo_yarp_lasersensor.so">
           <yarpConfigurationFile>model://ergoCub/conf/sensors/gazebo_ergocub_lidar.ini</yarpConfigurationFile>
         </plugin>
+  - frameName: SCSYS_L_ANKLE_2_FT_FRONT
+    linkName: l_foot_front
+    sensorName: l_foot_front_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_L_ANKLE_2_FT_REAR
+    linkName: l_foot_rear
+    sensorName: l_foot_rear_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_R_ANKLE_2_FT_FRONT
+    linkName: r_foot_front
+    sensorName: r_foot_front_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_R_ANKLE_2_FT_REAR
+    linkName: r_foot_rear
+    sensorName: r_foot_rear_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
 
 assignedMasses:
  torso_1   : 2.0645667
@@ -1246,74 +1290,6 @@ reverseRotationAxis:
     r_pinkie_prox
 
 XMLBlobs:
-    # left foot IMU (front)
-    - |
-            <gazebo reference="l_ankle_2">
-              <sensor name="l_foot_front_ft_imu" type="imu">
-                <always_on>1</always_on>
-                <update_rate>100</update_rate>
-                <pose>0.13525 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
-                </plugin>
-              </sensor>
-            </gazebo>
-    - |
-            <sensor name="l_foot_front_ft_imu" type="accelerometer">
-              <parent link="l_ankle_2" />
-              <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.13525 0 -0.07019999999999993" />
-            </sensor>
-    # left foot IMU (rear)
-    - |
-            <gazebo reference="l_ankle_2">
-              <sensor name="l_foot_rear_ft_imu" type="imu">
-                <always_on>1</always_on>
-                <update_rate>100</update_rate>
-                <pose>0.016000000000000004 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
-                </plugin>
-              </sensor>
-            </gazebo>
-    - |
-            <sensor name="l_foot_rear_ft_imu" type="accelerometer">
-              <parent link="l_ankle_2" />
-              <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
-            </sensor>
-    # right foot IMU (front)
-    - |
-            <gazebo reference="r_ankle_2">
-              <sensor name="r_foot_front_ft_imu" type="imu">
-                <always_on>1</always_on>
-                <update_rate>100</update_rate>
-                <pose>0.13525 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
-                </plugin>
-              </sensor>
-            </gazebo>
-    - |
-            <sensor name="r_foot_front_ft_imu" type="accelerometer">
-              <parent link="r_ankle_2" />
-              <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.13525 0 -0.07019999999999993" />
-            </sensor>
-    # right foot IMU (rear)
-    - |
-            <gazebo reference="r_ankle_2">
-              <sensor name="r_foot_rear_ft_imu" type="imu">
-                <always_on>1</always_on>
-                <update_rate>100</update_rate>
-                <pose>0.016000000000000004 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
-                </plugin>
-              </sensor>
-            </gazebo>
-    - |
-            <sensor name="r_foot_rear_ft_imu" type="accelerometer">
-              <parent link="r_ankle_2" />
-              <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
-            </sensor>
     # imu waist (workaround since simmechanics was not updated)
     - |
             <link name="waist_imu_0"/>

--- a/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_minContacts.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_minContacts.yaml
@@ -1263,6 +1263,50 @@ sensors:
         <plugin name="ergocub_yarp_gazebo_plugin_laser" filename="libgazebo_yarp_lasersensor.so">
           <yarpConfigurationFile>model://ergoCub/conf/sensors/gazebo_ergocub_lidar.ini</yarpConfigurationFile>
         </plugin>
+  - frameName: SCSYS_L_ANKLE_2_FT_FRONT
+    linkName: l_foot_front
+    sensorName: l_foot_front_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_L_ANKLE_2_FT_REAR
+    linkName: l_foot_rear
+    sensorName: l_foot_rear_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_R_ANKLE_2_FT_FRONT
+    linkName: r_foot_front
+    sensorName: r_foot_front_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_R_ANKLE_2_FT_REAR
+    linkName: r_foot_rear
+    sensorName: r_foot_rear_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
 
 assignedMasses:
  torso_1   : 2.0645667

--- a/urdf/ergoCub/robots/ergoCubGazeboV1_1/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubGazeboV1_1/model.urdf
@@ -2950,62 +2950,6 @@
     <parent link="r_hand_thumb_3"/>
     <child link="r_hand_thumb_skin_9"/>
   </joint>
-    <gazebo reference="l_ankle_2">
-    <sensor name="l_foot_front_ft_imu" type="imu">
-      <always_on>1</always_on>
-      <update_rate>100</update_rate>
-      <pose>0.13525 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
-      </plugin>
-    </sensor>
-  </gazebo>
-  <sensor name="l_foot_front_ft_imu" type="accelerometer">
-    <parent link="l_ankle_2" />
-    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.13525 0 -0.07019999999999993" />
-  </sensor>
-  <gazebo reference="l_ankle_2">
-    <sensor name="l_foot_rear_ft_imu" type="imu">
-      <always_on>1</always_on>
-      <update_rate>100</update_rate>
-      <pose>0.016000000000000004 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
-      </plugin>
-    </sensor>
-  </gazebo>
-  <sensor name="l_foot_rear_ft_imu" type="accelerometer">
-    <parent link="l_ankle_2" />
-    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
-  </sensor>
-  <gazebo reference="r_ankle_2">
-    <sensor name="r_foot_front_ft_imu" type="imu">
-      <always_on>1</always_on>
-      <update_rate>100</update_rate>
-      <pose>0.13525 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
-      </plugin>
-    </sensor>
-  </gazebo>
-  <sensor name="r_foot_front_ft_imu" type="accelerometer">
-    <parent link="r_ankle_2" />
-    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.13525 0 -0.07019999999999993" />
-  </sensor>
-  <gazebo reference="r_ankle_2">
-    <sensor name="r_foot_rear_ft_imu" type="imu">
-      <always_on>1</always_on>
-      <update_rate>100</update_rate>
-      <pose>0.016000000000000004 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
-      </plugin>
-    </sensor>
-  </gazebo>
-  <sensor name="r_foot_rear_ft_imu" type="accelerometer">
-    <parent link="r_ankle_2" />
-    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
-  </sensor>
   <link name="waist_imu_0"/>
   <joint name="waist_imu_0_fixed_joint" type="fixed">
     <origin xyz="0.0354497 0.00639688 0.060600" rpy="1.5708 0 -1.5708"/>
@@ -3627,5 +3571,61 @@
   <sensor name="lasersensor_head" type="ray">
     <parent link="head"/>
     <origin rpy="9.72195e-15 5.33157e-15 3.16761e-15 " xyz="5e-05 -1.93855e-15 0.134802"/>
+  </sensor>
+  <gazebo reference="l_foot_front">
+    <sensor name="l_foot_front_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>0 0 0 1.25667e-16 2.20112e-17 -2.0944 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_foot_front_ft_imu" type="accelerometer">
+    <parent link="l_foot_front"/>
+    <origin rpy="1.25667e-16 2.20112e-17 -2.0944 " xyz="0 0 0"/>
+  </sensor>
+  <gazebo reference="l_foot_rear">
+    <sensor name="l_foot_rear_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>0 0 0 1.25667e-16 2.20112e-17 -2.0944 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_foot_rear_ft_imu" type="accelerometer">
+    <parent link="l_foot_rear"/>
+    <origin rpy="1.25667e-16 2.20112e-17 -2.0944 " xyz="0 0 0"/>
+  </sensor>
+  <gazebo reference="r_foot_front">
+    <sensor name="r_foot_front_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>0 1.38778e-17 1.11022e-16 -1.0903e-16 -1.44222e-16 -2.0944 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_foot_front_ft_imu" type="accelerometer">
+    <parent link="r_foot_front"/>
+    <origin rpy="-1.0903e-16 -1.44222e-16 -2.0944 " xyz="0 1.38778e-17 1.11022e-16"/>
+  </sensor>
+  <gazebo reference="r_foot_rear">
+    <sensor name="r_foot_rear_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>3.46945e-18 0 0 -1.0903e-16 -1.44222e-16 -2.0944 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_foot_rear_ft_imu" type="accelerometer">
+    <parent link="r_foot_rear"/>
+    <origin rpy="-1.0903e-16 -1.44222e-16 -2.0944 " xyz="3.46945e-18 0 0"/>
   </sensor>
 </robot>

--- a/urdf/ergoCub/robots/ergoCubGazeboV1_1_minContacts/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubGazeboV1_1_minContacts/model.urdf
@@ -2764,7 +2764,7 @@
     <parent link="r_hand_thumb_3"/>
     <child link="r_hand_thumb_skin_9"/>
   </joint>
-    <gazebo reference="l_ankle_2">
+  <gazebo reference="l_ankle_2">
     <sensor name="l_foot_front_ft_imu" type="imu">
       <always_on>1</always_on>
       <update_rate>100</update_rate>
@@ -2775,8 +2775,8 @@
     </sensor>
   </gazebo>
   <sensor name="l_foot_front_ft_imu" type="accelerometer">
-    <parent link="l_ankle_2" />
-    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.13525 0 -0.07019999999999993" />
+    <parent link="l_ankle_2"/>
+    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.13525 0 -0.07019999999999993"/>
   </sensor>
   <gazebo reference="l_ankle_2">
     <sensor name="l_foot_rear_ft_imu" type="imu">
@@ -2789,8 +2789,8 @@
     </sensor>
   </gazebo>
   <sensor name="l_foot_rear_ft_imu" type="accelerometer">
-    <parent link="l_ankle_2" />
-    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
+    <parent link="l_ankle_2"/>
+    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993"/>
   </sensor>
   <gazebo reference="r_ankle_2">
     <sensor name="r_foot_front_ft_imu" type="imu">
@@ -2803,8 +2803,8 @@
     </sensor>
   </gazebo>
   <sensor name="r_foot_front_ft_imu" type="accelerometer">
-    <parent link="r_ankle_2" />
-    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.13525 0 -0.07019999999999993" />
+    <parent link="r_ankle_2"/>
+    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.13525 0 -0.07019999999999993"/>
   </sensor>
   <gazebo reference="r_ankle_2">
     <sensor name="r_foot_rear_ft_imu" type="imu">
@@ -2817,8 +2817,8 @@
     </sensor>
   </gazebo>
   <sensor name="r_foot_rear_ft_imu" type="accelerometer">
-    <parent link="r_ankle_2" />
-    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
+    <parent link="r_ankle_2"/>
+    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993"/>
   </sensor>
   <link name="waist_imu_0"/>
   <joint name="waist_imu_0_fixed_joint" type="fixed">
@@ -3441,5 +3441,61 @@
   <sensor name="lasersensor_head" type="ray">
     <parent link="head"/>
     <origin rpy="9.72195e-15 5.33157e-15 3.16761e-15 " xyz="5e-05 -1.93855e-15 0.134802"/>
+  </sensor>
+  <gazebo reference="l_foot_front">
+    <sensor name="l_foot_front_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>0 0 0 1.25667e-16 2.20112e-17 -2.0944 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_foot_front_ft_imu" type="accelerometer">
+    <parent link="l_foot_front"/>
+    <origin rpy="1.25667e-16 2.20112e-17 -2.0944 " xyz="0 0 0"/>
+  </sensor>
+  <gazebo reference="l_foot_rear">
+    <sensor name="l_foot_rear_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>0 0 0 1.25667e-16 2.20112e-17 -2.0944 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_foot_rear_ft_imu" type="accelerometer">
+    <parent link="l_foot_rear"/>
+    <origin rpy="1.25667e-16 2.20112e-17 -2.0944 " xyz="0 0 0"/>
+  </sensor>
+  <gazebo reference="r_foot_front">
+    <sensor name="r_foot_front_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>0 1.38778e-17 1.11022e-16 -1.0903e-16 -1.44222e-16 -2.0944 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_foot_front_ft_imu" type="accelerometer">
+    <parent link="r_foot_front"/>
+    <origin rpy="-1.0903e-16 -1.44222e-16 -2.0944 " xyz="0 1.38778e-17 1.11022e-16"/>
+  </sensor>
+  <gazebo reference="r_foot_rear">
+    <sensor name="r_foot_rear_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>3.46945e-18 0 0 -1.0903e-16 -1.44222e-16 -2.0944 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_foot_rear_ft_imu" type="accelerometer">
+    <parent link="r_foot_rear"/>
+    <origin rpy="-1.0903e-16 -1.44222e-16 -2.0944 " xyz="3.46945e-18 0 0"/>
   </sensor>
 </robot>

--- a/urdf/ergoCub/robots/ergoCubSN001/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubSN001/model.urdf
@@ -2950,62 +2950,6 @@
     <parent link="r_hand_thumb_3"/>
     <child link="r_hand_thumb_skin_9"/>
   </joint>
-    <gazebo reference="l_ankle_2">
-    <sensor name="l_foot_front_ft_imu" type="imu">
-      <always_on>1</always_on>
-      <update_rate>100</update_rate>
-      <pose>0.13525 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
-      </plugin>
-    </sensor>
-  </gazebo>
-  <sensor name="l_foot_front_ft_imu" type="accelerometer">
-    <parent link="l_ankle_2" />
-    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.13525 0 -0.07019999999999993" />
-  </sensor>
-  <gazebo reference="l_ankle_2">
-    <sensor name="l_foot_rear_ft_imu" type="imu">
-      <always_on>1</always_on>
-      <update_rate>100</update_rate>
-      <pose>0.016000000000000004 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
-      </plugin>
-    </sensor>
-  </gazebo>
-  <sensor name="l_foot_rear_ft_imu" type="accelerometer">
-    <parent link="l_ankle_2" />
-    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
-  </sensor>
-  <gazebo reference="r_ankle_2">
-    <sensor name="r_foot_front_ft_imu" type="imu">
-      <always_on>1</always_on>
-      <update_rate>100</update_rate>
-      <pose>0.13525 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
-      </plugin>
-    </sensor>
-  </gazebo>
-  <sensor name="r_foot_front_ft_imu" type="accelerometer">
-    <parent link="r_ankle_2" />
-    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.13525 0 -0.07019999999999993" />
-  </sensor>
-  <gazebo reference="r_ankle_2">
-    <sensor name="r_foot_rear_ft_imu" type="imu">
-      <always_on>1</always_on>
-      <update_rate>100</update_rate>
-      <pose>0.016000000000000004 0 -0.07019999999999993 0.0 -0.0 -2.0943952105869315</pose>
-      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
-        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
-      </plugin>
-    </sensor>
-  </gazebo>
-  <sensor name="r_foot_rear_ft_imu" type="accelerometer">
-    <parent link="r_ankle_2" />
-    <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
-  </sensor>
   <link name="waist_imu_0"/>
   <joint name="waist_imu_0_fixed_joint" type="fixed">
     <origin xyz="0.0354497 0.00639688 0.060600" rpy="1.5708 0 -1.5708"/>
@@ -3627,5 +3571,61 @@
   <sensor name="lasersensor_head" type="ray">
     <parent link="head"/>
     <origin rpy="9.72195e-15 5.33157e-15 3.16761e-15 " xyz="5e-05 -1.93855e-15 0.134802"/>
+  </sensor>
+  <gazebo reference="l_foot_front">
+    <sensor name="l_foot_front_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>0 0 0 1.25667e-16 2.20112e-17 -2.0944 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_foot_front_ft_imu" type="accelerometer">
+    <parent link="l_foot_front"/>
+    <origin rpy="1.25667e-16 2.20112e-17 -2.0944 " xyz="0 0 0"/>
+  </sensor>
+  <gazebo reference="l_foot_rear">
+    <sensor name="l_foot_rear_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>0 0 0 1.25667e-16 2.20112e-17 -2.0944 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_foot_rear_ft_imu" type="accelerometer">
+    <parent link="l_foot_rear"/>
+    <origin rpy="1.25667e-16 2.20112e-17 -2.0944 " xyz="0 0 0"/>
+  </sensor>
+  <gazebo reference="r_foot_front">
+    <sensor name="r_foot_front_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>0 1.38778e-17 1.11022e-16 -1.0903e-16 -1.44222e-16 -2.0944 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_front_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_foot_front_ft_imu" type="accelerometer">
+    <parent link="r_foot_front"/>
+    <origin rpy="-1.0903e-16 -1.44222e-16 -2.0944 " xyz="0 1.38778e-17 1.11022e-16"/>
+  </sensor>
+  <gazebo reference="r_foot_rear">
+    <sensor name="r_foot_rear_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>3.46945e-18 0 0 -1.0903e-16 -1.44222e-16 -2.0944 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_foot_rear_ft_imu" type="accelerometer">
+    <parent link="r_foot_rear"/>
+    <origin rpy="-1.0903e-16 -1.44222e-16 -2.0944 " xyz="3.46945e-18 0 0"/>
   </sensor>
 </robot>


### PR DESCRIPTION
They have been added by @GiulioRomualdi in;
- #217 

Using `xmlBlob` due to a bug in creo2urdf that has been fixed:
- https://github.com/icub-tech-iit/creo2urdf/pull/79 
- https://github.com/icub-tech-iit/creo2urdf/issues/77

Moreover seems that the ones adde in #217 were wrong:

- https://github.com/icub-tech-iit/creo2urdf/issues/77#issuecomment-1949929873