### PR TITLE
Update documentation on the URDF generation from Creo CAD assemblies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,11 @@ yarprobotinterface --config conf/launch_wholebodydynamics_ecub.xml
 
 ## URDF generation
 
-This repository hosts the configuration files for generating ergoCub urdf via [`creo2urdf`](https://github.com/icub-tech-iit/creo2urdf).
+This repository hosts the configuration files for generating ergoCub urdf. To generate the URDF, you need to have access to the `cad-mechanics` repo (that is currently private, if you need access ask it to the ergocub-software mantainer) and install the following repos and software:
+* You need to install the version of Creo required by [`cad-mechanics`](https://github.com/icub-tech-iit/cad-mechanics/).
+* You need to install the repos that contain the CAD models, i.e. cad-libraries (see https://github.com/icub-tech-iit/cad-libraries/wiki/Configure-PTC-Creo-with-cad-libraries) and cad-mechanics https://github.com/icub-tech-iit/cad-mechanics/.
+* You need to install creo2urdf following the README in https://github.com/icub-tech-iit/creo2urdf, either from source or using the binary available for each release.
+
 You can find there the relative documentation on how write those configuration files, and more details in the README of the following folders:
 * [`urdf/creo2urdf/data/ergocub1_0`](./urdf/creo2urdf/data/ergocub1_0)
 * [`urdf/creo2urdf/data/ergocub1_1`](./urdf/creo2urdf/data/ergocub1_1)

--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ yarprobotinterface --config conf/launch_wholebodydynamics_ecub.xml
 ```
 
 ## URDF generation
+
 This repository hosts the configuration files for generating ergoCub urdf via [`creo2urdf`](https://github.com/icub-tech-iit/creo2urdf).
-You can find there the relative documentation on how write those configuration files.
+You can find there the relative documentation on how write those configuration files, and more details in the README of the following folders:
+* [`urdf/creo2urdf/data/ergocub1_0`](./urdf/creo2urdf/data/ergocub1_0)
+* [`urdf/creo2urdf/data/ergocub1_1`](./urdf/creo2urdf/data/ergocub1_1)
 
 ### Maintainers
 This repository is maintained by:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ This repository hosts the configuration files for generating ergoCub urdf. To ge
 * You need to install the repos that contain the CAD models, i.e. cad-libraries (see https://github.com/icub-tech-iit/cad-libraries/wiki/Configure-PTC-Creo-with-cad-libraries) and cad-mechanics https://github.com/icub-tech-iit/cad-mechanics/.
 * You need to install creo2urdf following the README in https://github.com/icub-tech-iit/creo2urdf, either from source or using the binary available for each release.
 
+The CAD files used to generate the URDF models have been prepare according to the procedure described in https://github.com/icub-tech-iit/cad-libraries/wiki/Prepare-PTC-Creo-Mechanism-for-URDF .
+
 You can find there the relative documentation on how write those configuration files, and more details in the README of the following folders:
 * [`urdf/creo2urdf/data/ergocub1_0`](./urdf/creo2urdf/data/ergocub1_0)
 * [`urdf/creo2urdf/data/ergocub1_1`](./urdf/creo2urdf/data/ergocub1_1)

--- a/urdf/creo2urdf/data/ergocub1_0/README.md
+++ b/urdf/creo2urdf/data/ergocub1_0/README.md
@@ -1,6 +1,5 @@
-This directory contains file generated from `https://github.com/icub-tech-iit/cad-mechanics/blob/master/projects/simulation_model/ergocub_1-0/sim_ergocub_1-0.asm.1` (the file is currently private, please contact one of the mantainers of the repo for access) using the https://github.com/icub-tech-iit/cad-libraries/wiki/Prepare-PTC-Creo-Mechanism-for-URDF workflow .
 
-In particular, this is the mapping between the files contained in this folder and the files contained in `ergocub-software/urdf/ergoCub/robots`:
+This is the mapping between the CAD files, the files contained in this folder and the files contained in `ergocub-software/urdf/ergoCub/robots`:
 
 | CAD model in `cad-mechanics` | yaml file | csv file | YARP_ROBOT_NAME |
 |:----------:|:---------:|:----------:|:--------------:|

--- a/urdf/creo2urdf/data/ergocub1_0/README.md
+++ b/urdf/creo2urdf/data/ergocub1_0/README.md
@@ -1,3 +1,9 @@
-This directory contains file generated from `https://github.com/icub-tech-iit/cad-mechanics/blob/master/projects/simulation_model/ergocub_1-0/sim_ergocub_1-0.asm.1`
-using the https://github.com/icub-tech-iit/cad-mechanics-public/wiki/Creo-mechanism-to-URDF workflow .
-In particular the `SIM_ERGOCUB_1-0.xml` is directly the output obtained by the SimMechanics Link plugin.
+This directory contains file generated from `https://github.com/icub-tech-iit/cad-mechanics/blob/master/projects/simulation_model/ergocub_1-0/sim_ergocub_1-0.asm.1` (the file is currently private, please contact one of the mantainers of the repo for access) using the https://github.com/icub-tech-iit/cad-libraries/wiki/Prepare-PTC-Creo-Mechanism-for-URDF workflow .
+
+In particular, this is the mapping between the files contained in this folder and the files contained in `ergocub-software/urdf/ergoCub/robots`:
+
+| CAD model in `cad-mechanics` | yaml file | csv file | YARP_ROBOT_NAME |
+|:----------:|:---------:|:----------:|:--------------:|
+| `cad-mechanics/projects/simulation_model/ergocub_1-0/sim_ergocub_1-0.asm.1` | `ergocub-software/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options.yaml` | `ergocub-software/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options/ERGOCUB_all_options.csv` | `ergoCubSN000`  |
+| `cad-mechanics/projects/simulation_model/ergocub_1-0/sim_ergocub_1-0.asm.1` | `ergocub-software/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options/ERGOCUB_all_options_gazebo.yaml` | `ergocub-software/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options/ERGOCUB_all_options_gazebo.csv` | `ergoCubGazeboV1`  |
+| `cad-mechanics/projects/simulation_model/ergocub_1-0/sim_ergocub_1-0.asm.1` | `ergocub-software/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options/ERGOCUB_all_options_minContacts.yaml` | `ergocub-software/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options/ERGOCUB_all_options_minContacts.csv` | `ergoCubGazeboV1_minContacts`  |

--- a/urdf/creo2urdf/data/ergocub1_1/README.md
+++ b/urdf/creo2urdf/data/ergocub1_1/README.md
@@ -1,9 +1,7 @@
-This directory contains file generated from `https://github.com/icub-tech-iit/cad-mechanics/blob/master/projects/simulation_model/ergocub_1-1/sim_ergocub_1-1.asm.1` (the file is currently private, please contact one of the mantainers of the repo for access) using the https://github.com/icub-tech-iit/cad-libraries/wiki/Prepare-PTC-Creo-Mechanism-for-URDF workflow .
-
-In particular, this is the mapping between the files contained in this folder and the files contained in `ergocub-software/urdf/ergoCub/robots`:
+This is the mapping between the CAD files, the files contained in this folder and the files contained in `ergocub-software/urdf/ergoCub/robots`:
 
 | CAD model in `cad-mechanics` | yaml file | csv file | YARP_ROBOT_NAME |
 |:----------:|:---------:|:----------:|:--------------:|
-| `cad-mechanics/projects/simulation_model/ergocub_1-0/sim_ergocub_1-1.asm.1` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options.yaml` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options/ERGOCUB_all_options.csv` | `ergoCubSN001`  |
-| `cad-mechanics/projects/simulation_model/ergocub_1-0/sim_ergocub_1-1.asm.1` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options/ERGOCUB_all_options_gazebo.yaml` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options/ERGOCUB_all_options_gazebo.csv` | `ergoCubGazeboV1_1`  |
-| `cad-mechanics/projects/simulation_model/ergocub_1-0/sim_ergocub_1-0.asm.1` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options/ERGOCUB_all_options_minContacts.yaml` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options/ERGOCUB_all_options_minContacts.csv` | `ergoCubGazeboV1_1_minContacts`  |
+| `cad-mechanics/projects/simulation_model/ergocub_1-1/sim_ergocub_1-1.asm.1` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options.yaml` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options/ERGOCUB_all_options.csv` | `ergoCubSN001`  |
+| `cad-mechanics/projects/simulation_model/ergocub_1-1/sim_ergocub_1-1.asm.1` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options/ERGOCUB_all_options_gazebo.yaml` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options/ERGOCUB_all_options_gazebo.csv` | `ergoCubGazeboV1_1`  |
+| `cad-mechanics/projects/simulation_model/ergocub_1-1/sim_ergocub_1-1.asm.1` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options/ERGOCUB_all_options_minContacts.yaml` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options/ERGOCUB_all_options_minContacts.csv` | `ergoCubGazeboV1_1_minContacts`  |

--- a/urdf/creo2urdf/data/ergocub1_1/README.md
+++ b/urdf/creo2urdf/data/ergocub1_1/README.md
@@ -1,3 +1,9 @@
-This directory contains file generated from `https://github.com/icub-tech-iit/cad-mechanics/blob/master/projects/simulation_model/ergocub_1-0/sim_ergocub_1-0.asm.1`
-using the https://github.com/icub-tech-iit/cad-mechanics-public/wiki/Creo-mechanism-to-URDF workflow .
-In particular the `SIM_ERGOCUB_1-0.xml` is directly the output obtained by the SimMechanics Link plugin.
+This directory contains file generated from `https://github.com/icub-tech-iit/cad-mechanics/blob/master/projects/simulation_model/ergocub_1-1/sim_ergocub_1-1.asm.1` (the file is currently private, please contact one of the mantainers of the repo for access) using the https://github.com/icub-tech-iit/cad-libraries/wiki/Prepare-PTC-Creo-Mechanism-for-URDF workflow .
+
+In particular, this is the mapping between the files contained in this folder and the files contained in `ergocub-software/urdf/ergoCub/robots`:
+
+| CAD model in `cad-mechanics` | yaml file | csv file | YARP_ROBOT_NAME |
+|:----------:|:---------:|:----------:|:--------------:|
+| `cad-mechanics/projects/simulation_model/ergocub_1-0/sim_ergocub_1-1.asm.1` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options.yaml` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options/ERGOCUB_all_options.csv` | `ergoCubSN001`  |
+| `cad-mechanics/projects/simulation_model/ergocub_1-0/sim_ergocub_1-1.asm.1` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options/ERGOCUB_all_options_gazebo.yaml` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options/ERGOCUB_all_options_gazebo.csv` | `ergoCubGazeboV1_1`  |
+| `cad-mechanics/projects/simulation_model/ergocub_1-0/sim_ergocub_1-0.asm.1` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options/ERGOCUB_all_options_minContacts.yaml` | `ergocub-software/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options/ERGOCUB_all_options_minContacts.csv` | `ergoCubGazeboV1_1_minContacts`  |


### PR DESCRIPTION
I also refer to https://github.com/icub-tech-iit/cad-libraries/wiki/Prepare-PTC-Creo-Mechanism-for-URDF that now is a bit outdated (see https://github.com/icub-tech-iit/cad-libraries/issues/174), but eventually will be fixed.

cc @xela-95