### PR TITLE
[ergoCubSN00*/ergoCubGazeboV1*] Add alljoints-inertials to be aligned with real ergoCub

### DIFF
--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options.yaml
@@ -1116,6 +1116,74 @@ XMLBlobs:
               <parent link="r_ankle_2" />
               <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
             </sensor>
+    # left arm IMU 
+    - |
+            <gazebo reference="l_shoulder_2">
+              <sensor name="l_arm_ft_imu" type="imu">
+                <always_on>1</always_on>
+                <update_rate>100</update_rate>
+                <pose>0.0 -0.004350 -0.05430 3.14159265 -0.0 -1.57079633</pose>
+                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+                </plugin>
+              </sensor>
+            </gazebo>
+    - |
+            <sensor name="l_arm_ft_imu" type="accelerometer">
+              <parent link="l_shoulder_2" />
+              <origin rpy="3.14159265 -0.0 -1.57079633" xyz="0.0 -0.004350 -0.05430" />
+            </sensor>
+      # right arm IMU 
+    - |
+            <gazebo reference="r_shoulder_2">
+              <sensor name="r_arm_ft_imu" type="imu">
+                <always_on>1</always_on>
+                <update_rate>100</update_rate>
+                <pose>0.0 0.006850 -0.05430 3.14159265 -0.0 1.57079633</pose>
+                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+                </plugin>
+              </sensor>
+            </gazebo>
+    - |
+            <sensor name="r_arm_ft_imu" type="accelerometer">
+              <parent link="r_shoulder_2" />
+              <origin rpy="3.14159265 -0.0 1.57079633" xyz="0.0 0.006850 -0.05430" />
+            </sensor>
+    # left leg IMU 
+    - |
+            <gazebo reference="l_hip_2">
+              <sensor name="l_leg_ft_imu" type="imu">
+                <always_on>1</always_on>
+                <update_rate>100</update_rate>
+                <pose>0.03670 0.0 -0.08970 3.14159265 -0.0 2.61799368</pose>
+                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+                </plugin>
+              </sensor>
+            </gazebo>
+    - |
+            <sensor name="l_leg_ft_imu" type="accelerometer">
+              <parent link="l_hip_2" />
+              <origin rpy="3.14159265 -0.0 2.61799368" xyz="0.03670 0.0 -0.08970" />
+            </sensor>
+      # right leg IMU 
+    - |
+            <gazebo reference="r_hip_2">
+              <sensor name="r_leg_ft_imu" type="imu">
+                <always_on>1</always_on>
+                <update_rate>100</update_rate>
+                <pose>0.03670 0.0 -0.08970 3.14159265 -0.0 -2.61799368</pose>
+                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+                </plugin>
+              </sensor>
+            </gazebo>
+    - |
+            <sensor name="r_leg_ft_imu" type="accelerometer">
+              <parent link="r_hip_2" />
+              <origin rpy="3.14159265 -0.0 -2.61799368" xyz="0.03670 0.0 -0.08970" />
+            </sensor>
     # imu waist (workaround since simmechanics was not updated)
     - |
             <link name="waist_imu_0"/>

--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options.yaml
@@ -1122,7 +1122,7 @@ XMLBlobs:
               <sensor name="l_arm_ft_imu" type="imu">
                 <always_on>1</always_on>
                 <update_rate>100</update_rate>
-                <pose>0.0 -0.004350 -0.05430 3.14159265 -0.0 -1.57079633</pose>
+                <pose>-0.004350 0.0 -0.05430 3.14159265 -0.0 -1.57079633</pose>
                 <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
                   <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
                 </plugin>
@@ -1131,7 +1131,7 @@ XMLBlobs:
     - |
             <sensor name="l_arm_ft_imu" type="accelerometer">
               <parent link="l_shoulder_2" />
-              <origin rpy="3.14159265 -0.0 -1.57079633" xyz="0.0 -0.004350 -0.05430" />
+              <origin rpy="3.14159265 -0.0 -1.57079633" xyz="-0.004350 0.0 -0.05430" />
             </sensor>
       # right arm IMU 
     - |
@@ -1139,7 +1139,7 @@ XMLBlobs:
               <sensor name="r_arm_ft_imu" type="imu">
                 <always_on>1</always_on>
                 <update_rate>100</update_rate>
-                <pose>0.0 0.006850 -0.05430 3.14159265 -0.0 1.57079633</pose>
+                <pose>-0.006850 0.0 -0.05430 3.14159265 -0.0 1.57079633</pose>
                 <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
                   <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
                 </plugin>
@@ -1148,7 +1148,7 @@ XMLBlobs:
     - |
             <sensor name="r_arm_ft_imu" type="accelerometer">
               <parent link="r_shoulder_2" />
-              <origin rpy="3.14159265 -0.0 1.57079633" xyz="0.0 0.006850 -0.05430" />
+              <origin rpy="3.14159265 -0.0 1.57079633" xyz="-0.006850 0.0 -0.05430" />
             </sensor>
     # left leg IMU 
     - |

--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_gazebo.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_gazebo.yaml
@@ -1301,6 +1301,74 @@ XMLBlobs:
               <parent link="r_ankle_2" />
               <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
             </sensor>
+    # left arm IMU 
+    - |
+            <gazebo reference="l_shoulder_2">
+              <sensor name="l_arm_ft_imu" type="imu">
+                <always_on>1</always_on>
+                <update_rate>100</update_rate>
+                <pose>0.0 -0.004350 -0.05430 3.14159265 -0.0 -1.57079633</pose>
+                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+                </plugin>
+              </sensor>
+            </gazebo>
+    - |
+            <sensor name="l_arm_ft_imu" type="accelerometer">
+              <parent link="l_shoulder_2" />
+              <origin rpy="3.14159265 -0.0 -1.57079633" xyz="0.0 -0.004350 -0.05430" />
+            </sensor>
+      # right arm IMU 
+    - |
+            <gazebo reference="r_shoulder_2">
+              <sensor name="r_arm_ft_imu" type="imu">
+                <always_on>1</always_on>
+                <update_rate>100</update_rate>
+                <pose>0.0 0.006850 -0.05430 3.14159265 -0.0 1.57079633</pose>
+                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+                </plugin>
+              </sensor>
+            </gazebo>
+    - |
+            <sensor name="r_arm_ft_imu" type="accelerometer">
+              <parent link="r_shoulder_2" />
+              <origin rpy="3.14159265 -0.0 1.57079633" xyz="0.0 0.006850 -0.05430" />
+            </sensor>
+    # left leg IMU 
+    - |
+            <gazebo reference="l_hip_2">
+              <sensor name="l_leg_ft_imu" type="imu">
+                <always_on>1</always_on>
+                <update_rate>100</update_rate>
+                <pose>0.03670 0.0 -0.08970 3.14159265 -0.0 2.61799368</pose>
+                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+                </plugin>
+              </sensor>
+            </gazebo>
+    - |
+            <sensor name="l_leg_ft_imu" type="accelerometer">
+              <parent link="l_hip_2" />
+              <origin rpy="3.14159265 -0.0 2.61799368" xyz="0.03670 0.0 -0.08970" />
+            </sensor>
+      # right leg IMU 
+    - |
+            <gazebo reference="r_hip_2">
+              <sensor name="r_leg_ft_imu" type="imu">
+                <always_on>1</always_on>
+                <update_rate>100</update_rate>
+                <pose>0.03670 0.0 -0.08970 3.14159265 -0.0 -2.61799368</pose>
+                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+                </plugin>
+              </sensor>
+            </gazebo>
+    - |
+            <sensor name="r_leg_ft_imu" type="accelerometer">
+              <parent link="r_hip_2" />
+              <origin rpy="3.14159265 -0.0 -2.61799368" xyz="0.03670 0.0 -0.08970" />
+            </sensor>
     # imu waist (workaround since simmechanics was not updated)
     - |
             <link name="waist_imu_0"/>

--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_gazebo.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_gazebo.yaml
@@ -1307,7 +1307,7 @@ XMLBlobs:
               <sensor name="l_arm_ft_imu" type="imu">
                 <always_on>1</always_on>
                 <update_rate>100</update_rate>
-                <pose>0.0 -0.004350 -0.05430 3.14159265 -0.0 -1.57079633</pose>
+                <pose>-0.004350 0.0 -0.05430 3.14159265 -0.0 -1.57079633</pose>
                 <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
                   <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
                 </plugin>
@@ -1316,7 +1316,7 @@ XMLBlobs:
     - |
             <sensor name="l_arm_ft_imu" type="accelerometer">
               <parent link="l_shoulder_2" />
-              <origin rpy="3.14159265 -0.0 -1.57079633" xyz="0.0 -0.004350 -0.05430" />
+              <origin rpy="3.14159265 -0.0 -1.57079633" xyz="-0.004350 0.0 -0.05430" />
             </sensor>
       # right arm IMU 
     - |
@@ -1324,7 +1324,7 @@ XMLBlobs:
               <sensor name="r_arm_ft_imu" type="imu">
                 <always_on>1</always_on>
                 <update_rate>100</update_rate>
-                <pose>0.0 0.006850 -0.05430 3.14159265 -0.0 1.57079633</pose>
+                <pose>-0.006850 0.0 -0.05430 3.14159265 -0.0 1.57079633</pose>
                 <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
                   <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
                 </plugin>
@@ -1333,7 +1333,7 @@ XMLBlobs:
     - |
             <sensor name="r_arm_ft_imu" type="accelerometer">
               <parent link="r_shoulder_2" />
-              <origin rpy="3.14159265 -0.0 1.57079633" xyz="0.0 0.006850 -0.05430" />
+              <origin rpy="3.14159265 -0.0 1.57079633" xyz="-0.006850 0.0 -0.05430" />
             </sensor>
     # left leg IMU 
     - |

--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_minContacts.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_minContacts.yaml
@@ -1616,7 +1616,7 @@ XMLBlobs:
               <sensor name="l_arm_ft_imu" type="imu">
                 <always_on>1</always_on>
                 <update_rate>100</update_rate>
-                <pose>0.0 -0.004350 -0.05430 3.14159265 -0.0 -1.57079633</pose>
+                <pose>-0.004350 0.0 -0.05430 3.14159265 -0.0 -1.57079633</pose>
                 <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
                   <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
                 </plugin>
@@ -1625,7 +1625,7 @@ XMLBlobs:
     - |
             <sensor name="l_arm_ft_imu" type="accelerometer">
               <parent link="l_shoulder_2" />
-              <origin rpy="3.14159265 -0.0 -1.57079633" xyz="0.0 -0.004350 -0.05430" />
+              <origin rpy="3.14159265 -0.0 -1.57079633" xyz="-0.004350 0.0 -0.05430" />
             </sensor>
       # right arm IMU 
     - |
@@ -1633,7 +1633,7 @@ XMLBlobs:
               <sensor name="r_arm_ft_imu" type="imu">
                 <always_on>1</always_on>
                 <update_rate>100</update_rate>
-                <pose>0.0 0.006850 -0.05430 3.14159265 -0.0 1.57079633</pose>
+                <pose>-0.006850 0.0 -0.05430 3.14159265 -0.0 1.57079633</pose>
                 <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
                   <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
                 </plugin>
@@ -1642,7 +1642,7 @@ XMLBlobs:
     - |
             <sensor name="r_arm_ft_imu" type="accelerometer">
               <parent link="r_shoulder_2" />
-              <origin rpy="3.14159265 -0.0 1.57079633" xyz="0.0 0.006850 -0.05430" />
+              <origin rpy="3.14159265 -0.0 1.57079633" xyz="-0.00685 0.0 -0.05430" />
             </sensor>
     # left leg IMU 
     - |

--- a/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_minContacts.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/ERGOCUB_all_options_minContacts.yaml
@@ -1610,6 +1610,74 @@ XMLBlobs:
               <parent link="r_ankle_2" />
               <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
             </sensor>
+    # left arm IMU 
+    - |
+            <gazebo reference="l_shoulder_2">
+              <sensor name="l_arm_ft_imu" type="imu">
+                <always_on>1</always_on>
+                <update_rate>100</update_rate>
+                <pose>0.0 -0.004350 -0.05430 3.14159265 -0.0 -1.57079633</pose>
+                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+                </plugin>
+              </sensor>
+            </gazebo>
+    - |
+            <sensor name="l_arm_ft_imu" type="accelerometer">
+              <parent link="l_shoulder_2" />
+              <origin rpy="3.14159265 -0.0 -1.57079633" xyz="0.0 -0.004350 -0.05430" />
+            </sensor>
+      # right arm IMU 
+    - |
+            <gazebo reference="r_shoulder_2">
+              <sensor name="r_arm_ft_imu" type="imu">
+                <always_on>1</always_on>
+                <update_rate>100</update_rate>
+                <pose>0.0 0.006850 -0.05430 3.14159265 -0.0 1.57079633</pose>
+                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+                </plugin>
+              </sensor>
+            </gazebo>
+    - |
+            <sensor name="r_arm_ft_imu" type="accelerometer">
+              <parent link="r_shoulder_2" />
+              <origin rpy="3.14159265 -0.0 1.57079633" xyz="0.0 0.006850 -0.05430" />
+            </sensor>
+    # left leg IMU 
+    - |
+            <gazebo reference="l_hip_2">
+              <sensor name="l_leg_ft_imu" type="imu">
+                <always_on>1</always_on>
+                <update_rate>100</update_rate>
+                <pose>0.03670 0.0 -0.08970 3.14159265 -0.0 2.61799368</pose>
+                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+                </plugin>
+              </sensor>
+            </gazebo>
+    - |
+            <sensor name="l_leg_ft_imu" type="accelerometer">
+              <parent link="l_hip_2" />
+              <origin rpy="3.14159265 -0.0 2.61799368" xyz="0.03670 0.0 -0.08970" />
+            </sensor>
+      # right leg IMU 
+    - |
+            <gazebo reference="r_hip_2">
+              <sensor name="r_leg_ft_imu" type="imu">
+                <always_on>1</always_on>
+                <update_rate>100</update_rate>
+                <pose>0.03670 0.0 -0.08970 3.14159265 -0.0 -2.61799368</pose>
+                <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+                  <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+                </plugin>
+              </sensor>
+            </gazebo>
+    - |
+            <sensor name="r_leg_ft_imu" type="accelerometer">
+              <parent link="r_hip_2" />
+              <origin rpy="3.14159265 -0.0 -2.61799368" xyz="0.03670 0.0 -0.08970" />
+            </sensor>
     # imu waist (workaround since simmechanics was not updated)
     - |
             <link name="waist_imu_0"/>

--- a/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options.yaml
@@ -977,6 +977,50 @@ sensors:
         <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
             <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
         </plugin>
+  - frameName: SCSYS_L_SHOULDER_2_FT
+    linkName: l_shoulder_3
+    sensorName: l_arm_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_R_SHOULDER_2_FT
+    linkName: r_shoulder_3
+    sensorName: r_arm_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_L_HIP_2_FT
+    linkName: l_hip_3
+    sensorName: l_leg_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_R_HIP_2_FT
+    linkName: r_hip_3
+    sensorName: r_leg_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
 assignedCollisionGeometry:
     - linkName: r_foot_front
       geometricShape:

--- a/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_gazebo.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_gazebo.yaml
@@ -1193,6 +1193,50 @@ sensors:
         <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
             <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
         </plugin>
+  - frameName: SCSYS_L_SHOULDER_2_FT
+    linkName: l_shoulder_3
+    sensorName: l_arm_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_R_SHOULDER_2_FT
+    linkName: r_shoulder_3
+    sensorName: r_arm_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_L_HIP_2_FT
+    linkName: l_hip_3
+    sensorName: l_leg_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_R_HIP_2_FT
+    linkName: r_hip_3
+    sensorName: r_leg_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
 assignedMasses:
  torso_1   : 2.0645667
 

--- a/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_minContacts.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/ERGOCUB_all_options_minContacts.yaml
@@ -1307,7 +1307,50 @@ sensors:
         <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
             <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
         </plugin>
-
+  - frameName: SCSYS_L_SHOULDER_2_FT
+    linkName: l_shoulder_3
+    sensorName: l_arm_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_R_SHOULDER_2_FT
+    linkName: r_shoulder_3
+    sensorName: r_arm_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_L_HIP_2_FT
+    linkName: l_hip_3
+    sensorName: l_leg_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
+  - frameName: SCSYS_R_HIP_2_FT
+    linkName: r_hip_3
+    sensorName: r_leg_ft_imu
+    exportFrameInURDF: No
+    sensorType: "accelerometer"
+    updateRate: "100"
+    sensorBlobs:
+    - |
+        <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+            <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+        </plugin>
 assignedMasses:
  torso_1   : 2.0645667
 

--- a/urdf/ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini
+++ b/urdf/ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini
@@ -1,0 +1,2 @@
+disableImplicitNetworkWrapper
+yarpDeviceName l_arm_ft_sensor_inertial_hardware_device

--- a/urdf/ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini
+++ b/urdf/ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini
@@ -1,0 +1,2 @@
+disableImplicitNetworkWrapper
+yarpDeviceName l_leg_ft_sensor_inertial_hardware_device

--- a/urdf/ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini
+++ b/urdf/ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini
@@ -1,0 +1,2 @@
+disableImplicitNetworkWrapper
+yarpDeviceName r_arm_ft_sensor_inertial_hardware_device

--- a/urdf/ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini
+++ b/urdf/ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini
@@ -1,0 +1,2 @@
+disableImplicitNetworkWrapper
+yarpDeviceName r_leg_ft_sensor_inertial_hardware_device

--- a/urdf/ergoCub/conf/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/urdf/ergoCub/conf/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
+    <param name="OrientationSensorsNames">
+        (head_imu_0 l_arm_ft_imu l_leg_ft_imu l_foot_front_ft_imu l_foot_rear_ft_imu r_arm_ft_imu r_leg_ft_imu r_foot_front_ft_imu r_foot_rear_imu)
+    </param>
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="head_imu">  head_inertial_hardware_device </elem>
+            <elem name="left_arm_imu">  l_arm_ft_sensor_inertial_hardware_device </elem>
+            <elem name="left_leg_imu">  l_leg_ft_sensor_inertial_hardware_device </elem>
+            <elem name="left_foot_front_imu">  l_foot_front_ft_sensor_inertial_hardware_device </elem>
+            <elem name="left_foot_rear_imu">  l_foot_rear_ft_sensor_inertial_hardware_device </elem>
+            <elem name="right_arm_imu">  r_arm_ft_sensor_inertial_hardware_device </elem>
+            <elem name="right_leg_imu">  r_leg_ft_sensor_inertial_hardware_device </elem>
+            <elem name="right_foot_front_imu">  r_foot_front_ft_sensor_inertial_hardware_device </elem>
+            <elem name="right_foot_rear_imu">  r_foot_rear_ft_sensor_inertial_hardware_device </elem>
+        </paramlist>
+    </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/urdf/ergoCub/conf/wrappers/inertials/alljoints-inertials_remapper.xml
+++ b/urdf/ergoCub/conf/wrappers/inertials/alljoints-inertials_remapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_remapper" type="multipleanalogsensorsremapper">
     <param name="OrientationSensorsNames">
-        (head_imu_0 l_arm_ft_imu l_leg_ft_imu l_foot_front_ft_imu l_foot_rear_ft_imu r_arm_ft_imu r_leg_ft_imu r_foot_front_ft_imu r_foot_rear_imu)
+        (head_imu_0 l_arm_ft_imu l_leg_ft_imu l_foot_front_ft_imu l_foot_rear_ft_imu r_arm_ft_imu r_leg_ft_imu r_foot_front_ft_imu r_foot_rear_ft_imu)
     </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">

--- a/urdf/ergoCub/conf/wrappers/inertials/alljoints-inertials_wrapper.xml
+++ b/urdf/ergoCub/conf/wrappers/inertials/alljoints-inertials_wrapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-inertials_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">      10                           </param>
+    <param name="name"> ${portprefix}/alljoints/inertials   </param>
+
+    <action phase="startup" level="10" type="attach">
+        <paramlist name="networks">
+            <elem name="FirstStrain"> alljoints-inertials_remapper </elem>
+        </paramlist>
+       </action>
+    <action phase="shutdown" level="15" type="detach" />
+</device>

--- a/urdf/ergoCub/robots/ergoCubGazeboV1/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubGazeboV1/model.urdf
@@ -2953,7 +2953,7 @@
     <sensor name="l_arm_ft_imu" type="imu">
       <always_on>1</always_on>
       <update_rate>100</update_rate>
-      <pose>0.0 -0.004350 -0.05430 3.14159265 -0.0 -1.57079633</pose>
+      <pose>-0.004350 0.0 -0.05430 3.14159265 -0.0 -1.57079633</pose>
       <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
         <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
       </plugin>
@@ -2961,13 +2961,13 @@
   </gazebo>
   <sensor name="l_arm_ft_imu" type="accelerometer">
     <parent link="l_shoulder_2" />
-    <origin rpy="3.14159265 -0.0 -1.57079633" xyz="0.0 -0.004350 -0.05430" />
+    <origin rpy="3.14159265 -0.0 -1.57079633" xyz="-0.004350 0.0 -0.05430" />
   </sensor>
   <gazebo reference="r_shoulder_2">
     <sensor name="r_arm_ft_imu" type="imu">
       <always_on>1</always_on>
       <update_rate>100</update_rate>
-      <pose>0.0 0.006850 -0.05430 3.14159265 -0.0 1.57079633</pose>
+      <pose>-0.006850 0.0 -0.05430 3.14159265 -0.0 1.57079633</pose>
       <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
         <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
       </plugin>
@@ -2975,7 +2975,7 @@
   </gazebo>
   <sensor name="r_arm_ft_imu" type="accelerometer">
     <parent link="r_shoulder_2" />
-    <origin rpy="3.14159265 -0.0 1.57079633" xyz="0.0 0.006850 -0.05430" />
+    <origin rpy="3.14159265 -0.0 1.57079633" xyz="-0.006850 0.0 -0.05430" />
   </sensor>
   <gazebo reference="l_hip_2">
     <sensor name="l_leg_ft_imu" type="imu">

--- a/urdf/ergoCub/robots/ergoCubGazeboV1/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubGazeboV1/model.urdf
@@ -2949,6 +2949,62 @@
     <parent link="r_ankle_2" />
     <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
   </sensor>
+  <gazebo reference="l_shoulder_2">
+    <sensor name="l_arm_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0 -0.004350 -0.05430 3.14159265 -0.0 -1.57079633</pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_arm_ft_imu" type="accelerometer">
+    <parent link="l_shoulder_2" />
+    <origin rpy="3.14159265 -0.0 -1.57079633" xyz="0.0 -0.004350 -0.05430" />
+  </sensor>
+  <gazebo reference="r_shoulder_2">
+    <sensor name="r_arm_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0 0.006850 -0.05430 3.14159265 -0.0 1.57079633</pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_arm_ft_imu" type="accelerometer">
+    <parent link="r_shoulder_2" />
+    <origin rpy="3.14159265 -0.0 1.57079633" xyz="0.0 0.006850 -0.05430" />
+  </sensor>
+  <gazebo reference="l_hip_2">
+    <sensor name="l_leg_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.03670 0.0 -0.08970 3.14159265 -0.0 2.61799368</pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_leg_ft_imu" type="accelerometer">
+    <parent link="l_hip_2" />
+    <origin rpy="3.14159265 -0.0 2.61799368" xyz="0.03670 0.0 -0.08970" />
+  </sensor>
+  <gazebo reference="r_hip_2">
+    <sensor name="r_leg_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.03670 0.0 -0.08970 3.14159265 -0.0 -2.61799368</pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_leg_ft_imu" type="accelerometer">
+    <parent link="r_hip_2" />
+    <origin rpy="3.14159265 -0.0 -2.61799368" xyz="0.03670 0.0 -0.08970" />
+  </sensor>
   <link name="waist_imu_0"/>
   <joint name="waist_imu_0_fixed_joint" type="fixed">
   <origin xyz="0.0354497 0.00639688 0.060600" rpy="1.5708 0 -1.5708"/>

--- a/urdf/ergoCub/robots/ergoCubGazeboV1_1/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubGazeboV1_1/model.urdf
@@ -1241,8 +1241,8 @@
     </collision>
   </link>
   <joint name="l_index_add" type="revolute">
-    <origin xyz="0.022500000000000023 -0.0015000000000006952 -0.0685999999999996" rpy="-8.416895217637947e-16 -0.29670597224465534 5.804755322508926e-17"/>
-    <axis xyz="1.1895336853461886e-15 0.9999999999999999 -1.9812040713213337e-15"/>
+    <origin xyz="0.022500000000000034 -0.0015000000000006397 -0.06859999999999966" rpy="-8.126657451512497e-16 -0.2967059722446555 1.7414265967526777e-16"/>
+    <axis xyz="1.3005559878087045e-15 1.0000000000000002 -1.953448495705706e-15"/>
     <parent link="l_hand_palm"/>
     <child link="l_hand_index_1"/>
     <limit lower="0" upper="0.2617993877991494" effort="1e+9" velocity="1e+9"/>
@@ -1571,8 +1571,8 @@
     </collision>
   </link>
   <joint name="l_index_prox" type="revolute">
-    <origin xyz="0.00919253334679343 0 -0.030713451309624218" rpy="-3.0531133177191815e-16 -7.023611484080483e-10 -7.771561172376096e-16"/>
-    <axis xyz="-1 8.326672684688522e-17 7.023654435833748e-10"/>
+    <origin xyz="0.009192533346793416 -2.7755575615628914e-17 -0.030713451309624162" rpy="-2.7755575615628914e-16 -7.023611553469422e-10 -7.771561172376094e-16"/>
+    <axis xyz="-1.0000000000000002 2.7755575615627613e-17 7.023654366444809e-10"/>
     <parent link="l_hand_index_1"/>
     <child link="l_hand_index_2"/>
     <limit lower="0" upper="1.5707963267948966" effort="1e+9" velocity="1e+9"/>
@@ -1604,8 +1604,8 @@
     </collision>
   </link>
   <joint name="l_index_dist" type="revolute">
-    <origin xyz="-1.3877787807814457e-17 -0.001500000000000029 -0.03999999999999987" rpy="-7.482326172536535e-8 1.8041124150158794e-16 -6.106226635438361e-16"/>
-    <axis xyz="-1 -2.359224176539984e-16 4.163337069211178e-17"/>
+    <origin xyz="-2.7755575615628914e-17 -0.0014999999999999736 -0.039999999999999925" rpy="-7.482326169760975e-8 1.734723475976807e-16 -6.106226635438361e-16"/>
+    <axis xyz="-1 -1.804112664227406e-16 9.020562801946248e-17"/>
     <parent link="l_hand_index_2"/>
     <child link="l_hand_index_3"/>
     <limit lower="0" upper="1.7994344588061537" effort="1e+9" velocity="1e+9"/>
@@ -3750,5 +3750,61 @@
   <sensor name="r_foot_rear_ft_imu" type="accelerometer">
     <parent link="r_foot_rear"/>
     <origin rpy="-1.0903e-16 -1.44222e-16 -2.0944 " xyz="3.46945e-18 0 0"/>
+  </sensor>
+  <gazebo reference="l_shoulder_3">
+    <sensor name="l_arm_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>-3.46945e-18 0 0 3.14159 1.94289e-16 -1.5708 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_arm_ft_imu" type="accelerometer">
+    <parent link="l_shoulder_3"/>
+    <origin rpy="3.14159 1.94289e-16 -1.5708 " xyz="-3.46945e-18 0 0"/>
+  </sensor>
+  <gazebo reference="r_shoulder_3">
+    <sensor name="r_arm_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>0 0 0 -3.14159 -2.77556e-17 1.5708 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_arm_ft_imu" type="accelerometer">
+    <parent link="r_shoulder_3"/>
+    <origin rpy="-3.14159 -2.77556e-17 1.5708 " xyz="0 0 0"/>
+  </sensor>
+  <gazebo reference="l_hip_3">
+    <sensor name="l_leg_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>5.20417e-18 0 0 3.14159 -2.02132e-15 2.61799 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_leg_ft_imu" type="accelerometer">
+    <parent link="l_hip_3"/>
+    <origin rpy="3.14159 -2.02132e-15 2.61799 " xyz="5.20417e-18 0 0"/>
+  </sensor>
+  <gazebo reference="r_hip_3">
+    <sensor name="r_leg_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>1.21431e-17 2.77556e-17 5.55112e-17 3.14159 2.98881e-16 -2.61799 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_leg_ft_imu" type="accelerometer">
+    <parent link="r_hip_3"/>
+    <origin rpy="3.14159 2.98881e-16 -2.61799 " xyz="1.21431e-17 2.77556e-17 5.55112e-17"/>
   </sensor>
 </robot>

--- a/urdf/ergoCub/robots/ergoCubGazeboV1_1_minContacts/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubGazeboV1_1_minContacts/model.urdf
@@ -1127,8 +1127,8 @@
     </collision>
   </link>
   <joint name="l_index_add" type="revolute">
-    <origin xyz="0.022500000000000023 -0.0015000000000006952 -0.0685999999999996" rpy="-8.416895217637947e-16 -0.29670597224465534 5.804755322508926e-17"/>
-    <axis xyz="1.1895336853461886e-15 0.9999999999999999 -1.9812040713213337e-15"/>
+    <origin xyz="0.022500000000000034 -0.0015000000000006397 -0.06859999999999966" rpy="-8.126657451512497e-16 -0.2967059722446555 1.7414265967526777e-16"/>
+    <axis xyz="1.3005559878087045e-15 1.0000000000000002 -1.953448495705706e-15"/>
     <parent link="l_hand_palm"/>
     <child link="l_hand_index_1"/>
     <limit lower="0" upper="0.2617993877991494" effort="1e+9" velocity="1e+9"/>
@@ -1427,8 +1427,8 @@
     </collision>
   </link>
   <joint name="l_index_prox" type="revolute">
-    <origin xyz="0.00919253334679343 0 -0.030713451309624218" rpy="-3.0531133177191815e-16 -7.023611484080483e-10 -7.771561172376096e-16"/>
-    <axis xyz="-1 8.326672684688522e-17 7.023654435833748e-10"/>
+    <origin xyz="0.009192533346793416 -2.7755575615628914e-17 -0.030713451309624162" rpy="-2.7755575615628914e-16 -7.023611553469422e-10 -7.771561172376094e-16"/>
+    <axis xyz="-1.0000000000000002 2.7755575615627613e-17 7.023654366444809e-10"/>
     <parent link="l_hand_index_1"/>
     <child link="l_hand_index_2"/>
     <limit lower="0" upper="1.5707963267948966" effort="1e+9" velocity="1e+9"/>
@@ -1457,8 +1457,8 @@
     </collision>
   </link>
   <joint name="l_index_dist" type="revolute">
-    <origin xyz="-1.3877787807814457e-17 -0.001500000000000029 -0.03999999999999987" rpy="-7.482326172536535e-8 1.8041124150158794e-16 -6.106226635438361e-16"/>
-    <axis xyz="-1 -2.359224176539984e-16 4.163337069211178e-17"/>
+    <origin xyz="-2.7755575615628914e-17 -0.0014999999999999736 -0.039999999999999925" rpy="-7.482326169760975e-8 1.734723475976807e-16 -6.106226635438361e-16"/>
+    <axis xyz="-1 -1.804112664227406e-16 9.020562801946248e-17"/>
     <parent link="l_hand_index_2"/>
     <child link="l_hand_index_3"/>
     <limit lower="0" upper="1.7994344588061537" effort="1e+9" velocity="1e+9"/>
@@ -3564,5 +3564,61 @@
   <sensor name="r_foot_rear_ft_imu" type="accelerometer">
     <parent link="r_foot_rear"/>
     <origin rpy="-1.0903e-16 -1.44222e-16 -2.0944 " xyz="3.46945e-18 0 0"/>
+  </sensor>
+  <gazebo reference="l_shoulder_3">
+    <sensor name="l_arm_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>-3.46945e-18 0 0 3.14159 1.94289e-16 -1.5708 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_arm_ft_imu" type="accelerometer">
+    <parent link="l_shoulder_3"/>
+    <origin rpy="3.14159 1.94289e-16 -1.5708 " xyz="-3.46945e-18 0 0"/>
+  </sensor>
+  <gazebo reference="r_shoulder_3">
+    <sensor name="r_arm_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>0 0 0 -3.14159 -2.77556e-17 1.5708 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_arm_ft_imu" type="accelerometer">
+    <parent link="r_shoulder_3"/>
+    <origin rpy="-3.14159 -2.77556e-17 1.5708 " xyz="0 0 0"/>
+  </sensor>
+  <gazebo reference="l_hip_3">
+    <sensor name="l_leg_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>5.20417e-18 0 0 3.14159 -2.02132e-15 2.61799 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_leg_ft_imu" type="accelerometer">
+    <parent link="l_hip_3"/>
+    <origin rpy="3.14159 -2.02132e-15 2.61799 " xyz="5.20417e-18 0 0"/>
+  </sensor>
+  <gazebo reference="r_hip_3">
+    <sensor name="r_leg_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>1.21431e-17 2.77556e-17 5.55112e-17 3.14159 2.98881e-16 -2.61799 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_leg_ft_imu" type="accelerometer">
+    <parent link="r_hip_3"/>
+    <origin rpy="3.14159 2.98881e-16 -2.61799 " xyz="1.21431e-17 2.77556e-17 5.55112e-17"/>
   </sensor>
 </robot>

--- a/urdf/ergoCub/robots/ergoCubGazeboV1_minContacts/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubGazeboV1_minContacts/model.urdf
@@ -2953,7 +2953,7 @@
     <sensor name="l_arm_ft_imu" type="imu">
       <always_on>1</always_on>
       <update_rate>100</update_rate>
-      <pose>0.0 -0.004350 -0.05430 3.14159265 -0.0 -1.57079633</pose>
+      <pose>-0.004350 0.0 -0.05430 3.14159265 -0.0 -1.57079633</pose>
       <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
         <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
       </plugin>
@@ -2961,13 +2961,13 @@
   </gazebo>
   <sensor name="l_arm_ft_imu" type="accelerometer">
     <parent link="l_shoulder_2" />
-    <origin rpy="3.14159265 -0.0 -1.57079633" xyz="0.0 -0.004350 -0.05430" />
+    <origin rpy="3.14159265 -0.0 -1.57079633" xyz="-0.004350 0.0 -0.05430" />
   </sensor>
   <gazebo reference="r_shoulder_2">
     <sensor name="r_arm_ft_imu" type="imu">
       <always_on>1</always_on>
       <update_rate>100</update_rate>
-      <pose>0.0 0.006850 -0.05430 3.14159265 -0.0 1.57079633</pose>
+      <pose>-0.006850 0.0 -0.05430 3.14159265 -0.0 1.57079633</pose>
       <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
         <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
       </plugin>
@@ -2975,7 +2975,7 @@
   </gazebo>
   <sensor name="r_arm_ft_imu" type="accelerometer">
     <parent link="r_shoulder_2" />
-    <origin rpy="3.14159265 -0.0 1.57079633" xyz="0.0 0.006850 -0.05430" />
+    <origin rpy="3.14159265 -0.0 1.57079633" xyz="-0.006850 0.0 -0.05430" />
   </sensor>
   <gazebo reference="l_hip_2">
     <sensor name="l_leg_ft_imu" type="imu">

--- a/urdf/ergoCub/robots/ergoCubGazeboV1_minContacts/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubGazeboV1_minContacts/model.urdf
@@ -2949,6 +2949,62 @@
     <parent link="r_ankle_2" />
     <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
   </sensor>
+  <gazebo reference="l_shoulder_2">
+    <sensor name="l_arm_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0 -0.004350 -0.05430 3.14159265 -0.0 -1.57079633</pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_arm_ft_imu" type="accelerometer">
+    <parent link="l_shoulder_2" />
+    <origin rpy="3.14159265 -0.0 -1.57079633" xyz="0.0 -0.004350 -0.05430" />
+  </sensor>
+  <gazebo reference="r_shoulder_2">
+    <sensor name="r_arm_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0 0.006850 -0.05430 3.14159265 -0.0 1.57079633</pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_arm_ft_imu" type="accelerometer">
+    <parent link="r_shoulder_2" />
+    <origin rpy="3.14159265 -0.0 1.57079633" xyz="0.0 0.006850 -0.05430" />
+  </sensor>
+  <gazebo reference="l_hip_2">
+    <sensor name="l_leg_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.03670 0.0 -0.08970 3.14159265 -0.0 2.61799368</pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_leg_ft_imu" type="accelerometer">
+    <parent link="l_hip_2" />
+    <origin rpy="3.14159265 -0.0 2.61799368" xyz="0.03670 0.0 -0.08970" />
+  </sensor>
+  <gazebo reference="r_hip_2">
+    <sensor name="r_leg_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.03670 0.0 -0.08970 3.14159265 -0.0 -2.61799368</pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_leg_ft_imu" type="accelerometer">
+    <parent link="r_hip_2" />
+    <origin rpy="3.14159265 -0.0 -2.61799368" xyz="0.03670 0.0 -0.08970" />
+  </sensor>
   <link name="waist_imu_0"/>
   <joint name="waist_imu_0_fixed_joint" type="fixed">
   <origin xyz="0.0354497 0.00639688 0.060600" rpy="1.5708 0 -1.5708"/>

--- a/urdf/ergoCub/robots/ergoCubSN000/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubSN000/model.urdf
@@ -2953,7 +2953,7 @@
     <sensor name="l_arm_ft_imu" type="imu">
       <always_on>1</always_on>
       <update_rate>100</update_rate>
-      <pose>0.0 -0.004350 -0.05430 3.14159265 -0.0 -1.57079633</pose>
+      <pose>-0.004350 0.0 -0.05430 3.14159265 -0.0 -1.57079633</pose>
       <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
         <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
       </plugin>
@@ -2961,13 +2961,13 @@
   </gazebo>
   <sensor name="l_arm_ft_imu" type="accelerometer">
     <parent link="l_shoulder_2" />
-    <origin rpy="3.14159265 -0.0 -1.57079633" xyz="0.0 -0.004350 -0.05430" />
+    <origin rpy="3.14159265 -0.0 -1.57079633" xyz="-0.004350 0.0 -0.05430" />
   </sensor>
   <gazebo reference="r_shoulder_2">
     <sensor name="r_arm_ft_imu" type="imu">
       <always_on>1</always_on>
       <update_rate>100</update_rate>
-      <pose>0.0 0.006850 -0.05430 3.14159265 -0.0 1.57079633</pose>
+      <pose>-0.006850 0.0 -0.05430 3.14159265 -0.0 1.57079633</pose>
       <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
         <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
       </plugin>
@@ -2975,7 +2975,7 @@
   </gazebo>
   <sensor name="r_arm_ft_imu" type="accelerometer">
     <parent link="r_shoulder_2" />
-    <origin rpy="3.14159265 -0.0 1.57079633" xyz="0.0 0.006850 -0.05430" />
+    <origin rpy="3.14159265 -0.0 1.57079633" xyz="-0.006850 0.0 -0.05430" />
   </sensor>
   <gazebo reference="l_hip_2">
     <sensor name="l_leg_ft_imu" type="imu">

--- a/urdf/ergoCub/robots/ergoCubSN000/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubSN000/model.urdf
@@ -2949,6 +2949,62 @@
     <parent link="r_ankle_2" />
     <origin rpy="0.0 -0.0 -2.0943952105869315" xyz="0.016000000000000004 0 -0.07019999999999993" />
   </sensor>
+  <gazebo reference="l_shoulder_2">
+    <sensor name="l_arm_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0 -0.004350 -0.05430 3.14159265 -0.0 -1.57079633</pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_arm_ft_imu" type="accelerometer">
+    <parent link="l_shoulder_2" />
+    <origin rpy="3.14159265 -0.0 -1.57079633" xyz="0.0 -0.004350 -0.05430" />
+  </sensor>
+  <gazebo reference="r_shoulder_2">
+    <sensor name="r_arm_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.0 0.006850 -0.05430 3.14159265 -0.0 1.57079633</pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_arm_ft_imu" type="accelerometer">
+    <parent link="r_shoulder_2" />
+    <origin rpy="3.14159265 -0.0 1.57079633" xyz="0.0 0.006850 -0.05430" />
+  </sensor>
+  <gazebo reference="l_hip_2">
+    <sensor name="l_leg_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.03670 0.0 -0.08970 3.14159265 -0.0 2.61799368</pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_leg_ft_imu" type="accelerometer">
+    <parent link="l_hip_2" />
+    <origin rpy="3.14159265 -0.0 2.61799368" xyz="0.03670 0.0 -0.08970" />
+  </sensor>
+  <gazebo reference="r_hip_2">
+    <sensor name="r_leg_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100</update_rate>
+      <pose>0.03670 0.0 -0.08970 3.14159265 -0.0 -2.61799368</pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_leg_ft_imu" type="accelerometer">
+    <parent link="r_hip_2" />
+    <origin rpy="3.14159265 -0.0 -2.61799368" xyz="0.03670 0.0 -0.08970" />
+  </sensor>
   <link name="waist_imu_0"/>
   <joint name="waist_imu_0_fixed_joint" type="fixed">
   <origin xyz="0.0354497 0.00639688 0.060600" rpy="1.5708 0 -1.5708"/>

--- a/urdf/ergoCub/robots/ergoCubSN001/model.urdf
+++ b/urdf/ergoCub/robots/ergoCubSN001/model.urdf
@@ -3751,4 +3751,60 @@
     <parent link="r_foot_rear"/>
     <origin rpy="-1.0903e-16 -1.44222e-16 -2.0944 " xyz="3.46945e-18 0 0"/>
   </sensor>
+  <gazebo reference="l_shoulder_3">
+    <sensor name="l_arm_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>-3.46945e-18 0 0 3.14159 1.94289e-16 -1.5708 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_arm_ft_imu" type="accelerometer">
+    <parent link="l_shoulder_3"/>
+    <origin rpy="3.14159 1.94289e-16 -1.5708 " xyz="-3.46945e-18 0 0"/>
+  </sensor>
+  <gazebo reference="r_shoulder_3">
+    <sensor name="r_arm_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>0 0 0 -3.14159 -2.77556e-17 1.5708 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_arm_ft_imu" type="accelerometer">
+    <parent link="r_shoulder_3"/>
+    <origin rpy="-3.14159 -2.77556e-17 1.5708 " xyz="0 0 0"/>
+  </sensor>
+  <gazebo reference="l_hip_3">
+    <sensor name="l_leg_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>5.20417e-18 0 0 3.14159 -2.02132e-15 2.61799 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="l_leg_ft_imu" type="accelerometer">
+    <parent link="l_hip_3"/>
+    <origin rpy="3.14159 -2.02132e-15 2.61799 " xyz="5.20417e-18 0 0"/>
+  </sensor>
+  <gazebo reference="r_hip_3">
+    <sensor name="r_leg_ft_imu" type="imu">
+      <always_on>1</always_on>
+      <update_rate>100.000000</update_rate>
+      <pose>1.21431e-17 2.77556e-17 5.55112e-17 3.14159 2.98881e-16 -2.61799 </pose>
+      <plugin name="ergocub_yarp_gazebo_plugin_IMU" filename="libgazebo_yarp_imu.so">
+        <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <sensor name="r_leg_ft_imu" type="accelerometer">
+    <parent link="r_hip_3"/>
+    <origin rpy="3.14159 2.98881e-16 -2.61799 " xyz="1.21431e-17 2.77556e-17 5.55112e-17"/>
+  </sensor>
 </robot>


### PR DESCRIPTION
This is the twin of https://github.com/robotology/icub-models-generator/pull/264. In this PR were added:

- the .ini files for the inertials for the IMU sensors mounted on the FT of the arms and the legs. The ones of the feet were already added in:
  -  https://github.com/icub-tech-iit/ergocub-software/pull/217
  -  https://github.com/icub-tech-iit/ergocub-software/pull/222)
- the `alljoints-inertials_wrapper.xml` and `alljoints-inertials_remapper.xml` to wrap up the inertials measurements (I didn't added them to the xml used by the yarprobotinterface by default);
- for  ergoCub1.0 models (i.e. ergoCubGazeboV1, ergoCubGazeboV1_minContacts, ergoCubSN000): the `arms and legs IMU` as `XMLBlobs` in the .yaml and manually added to the urdf;
-  ergoCub1.1 models (i.e. ergoCubGazeboV1_1, ergoCubGazeboV1_1_minContacts, ergoCubSN001): the `arms and legs IMU` as `sensors` in the .yaml, so the correspondent urdf can be regenerated.

For the time being, I would keep this PR in draft since I want to see if the pose I added as XMLBlobs are correct.

cc @Nicogene @pattacini @traversaro 