### PR TITLE
Fix alljoints inertials to work also on `gz-sim`

### DIFF
--- a/urdf/creo2urdf/data/ergocub1_0/base_1_0.yaml
+++ b/urdf/creo2urdf/data/ergocub1_0/base_1_0.yaml
@@ -1379,6 +1379,12 @@ XMLBlobs:
             </gazebo>
     - |
             <gazebo>
+            <plugin name="gzyarp::Imu" filename="gz-sim-yarp-imu-system">
+              <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+            </plugin>
+            </gazebo>
+    - |
+            <gazebo>
             <plugin name="controlboard_left_leg" filename="libgazebo_yarp_controlboard.so">
             <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_left_leg.ini</yarpConfigurationFile>
             </plugin>
@@ -1490,6 +1496,12 @@ XMLBlobs:
             <gazebo>
             <plugin name="gzyarp::Imu" filename="gz-sim-yarp-imu-system">
               <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
+            </plugin>
+            </gazebo>
+    - |
+            <gazebo>
+            <plugin name="gzyarp::Imu" filename="gz-sim-yarp-imu-system">
+              <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
             </plugin>
             </gazebo>
     - |
@@ -1607,6 +1619,12 @@ XMLBlobs:
             </plugin>
             </gazebo>
     - |
+            <gazebo>
+            <plugin name="gzyarp::Imu" filename="gz-sim-yarp-imu-system">
+              <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+            </plugin>
+            </gazebo>
+    - |
             <gazebo reference="l_shoulder_pitch">
               <implicitSpringDamper>1</implicitSpringDamper>
             </gazebo>
@@ -1665,6 +1683,12 @@ XMLBlobs:
             <gazebo>
             <plugin name="gzyarp::ForceTorque" filename="gz-sim-yarp-forcetorque-system">
               <yarpConfigurationFile>model://ergoCub/conf/FT/gazebo_ergocub_right_arm_ft.ini</yarpConfigurationFile>
+            </plugin>
+            </gazebo>
+    - |
+            <gazebo>
+            <plugin name="gzyarp::Imu" filename="gz-sim-yarp-imu-system">
+              <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
             </plugin>
             </gazebo>
     - |

--- a/urdf/creo2urdf/data/ergocub1_1/base_1_1.yaml
+++ b/urdf/creo2urdf/data/ergocub1_1/base_1_1.yaml
@@ -1170,7 +1170,7 @@ XMLBlobs:
             <plugin name="gzyarp::Imu" filename="gz-sim-yarp-imu-system">
               <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_waist_inertial.ini</yarpConfigurationFile>
             </plugin>
-            </gazebo>            
+            </gazebo>
     - |
             <sensor name="waist_imu_0" type="accelerometer">
             <parent link="torso_1"/>
@@ -1208,6 +1208,18 @@ XMLBlobs:
             <gazebo>
             <plugin name="gzyarp::ForceTorque" filename="gz-sim-yarp-forcetorque-system">
               <yarpConfigurationFile>model://ergoCub/conf/FT/gazebo_ergocub_right_arm_ft.ini</yarpConfigurationFile>
+            </plugin>
+            </gazebo>
+    - |
+            <gazebo>
+            <plugin name="gzyarp::Imu" filename="gz-sim-yarp-imu-system">
+              <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
+            </plugin>
+            </gazebo>
+    - |
+            <gazebo>
+            <plugin name="gzyarp::Imu" filename="gz-sim-yarp-imu-system">
+              <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini</yarpConfigurationFile>
             </plugin>
             </gazebo>
     - |
@@ -1340,6 +1352,12 @@ XMLBlobs:
             </gazebo>
     - |
             <gazebo>
+            <plugin name="gzyarp::Imu" filename="gz-sim-yarp-imu-system">
+              <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
+            </plugin>
+            </gazebo>
+    - |
+            <gazebo>
             <plugin name="controlboard_left_leg" filename="libgazebo_yarp_controlboard.so">
             <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_left_leg.ini</yarpConfigurationFile>
             </plugin>
@@ -1452,6 +1470,12 @@ XMLBlobs:
             <gazebo>
             <plugin name="gzyarp::Imu" filename="gz-sim-yarp-imu-system">
               <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_foot_rear_ft_sensor_inertial.ini</yarpConfigurationFile>
+            </plugin>
+            </gazebo>
+    - |
+            <gazebo>
+            <plugin name="gzyarp::Imu" filename="gz-sim-yarp-imu-system">
+              <yarpConfigurationFile>model://ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini</yarpConfigurationFile>
             </plugin>
             </gazebo>
     - |

--- a/urdf/ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini
+++ b/urdf/ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini
@@ -1,2 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName l_arm_ft_sensor_inertial_hardware_device
+parentLinkName l_arm
+sensorName l_arm_ft_imu

--- a/urdf/ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini
+++ b/urdf/ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini
@@ -1,2 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName l_leg_ft_sensor_inertial_hardware_device
+parentLinkName l_leg
+sensorName l_leg_ft_imu

--- a/urdf/ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini
+++ b/urdf/ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini
@@ -1,2 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName r_arm_ft_sensor_inertial_hardware_device
+parentLinkName r_arm
+sensorName r_arm_ft_imu

--- a/urdf/ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini
+++ b/urdf/ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini
@@ -1,2 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName r_leg_ft_sensor_inertial_hardware_device
+parentLinkName r_leg
+sensorName r_leg_ft_imu


### PR DESCRIPTION
Fixing regression of https://github.com/icub-tech-iit/ergocub-software/pull/232 concerning the use of ergocub UDRF files on `gz-sim` through `gz-sim-yarp-plugins`.

Related issue https://github.com/robotology/gz-sim-yarp-plugins/issues/173
Related PR: https://github.com/icub-tech-iit/ergocub-software/pull/251

CC @traversaro 