### PR TITLE
Fix IMU parent link names for `gz-sim-yarp-plugins`

### DIFF
--- a/urdf/ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini
+++ b/urdf/ergoCub/conf/gazebo_ergocub_l_arm_ft_sensor_inertial.ini
@@ -1,4 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName l_arm_ft_sensor_inertial_hardware_device
-parentLinkName l_arm
+parentLinkName l_shoulder_3
 sensorName l_arm_ft_imu

--- a/urdf/ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini
+++ b/urdf/ergoCub/conf/gazebo_ergocub_l_leg_ft_sensor_inertial.ini
@@ -1,4 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName l_leg_ft_sensor_inertial_hardware_device
-parentLinkName l_leg
+parentLinkName l_hip_3
 sensorName l_leg_ft_imu

--- a/urdf/ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini
+++ b/urdf/ergoCub/conf/gazebo_ergocub_r_arm_ft_sensor_inertial.ini
@@ -1,4 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName r_arm_ft_sensor_inertial_hardware_device
-parentLinkName r_arm
+parentLinkName r_shoulder_3
 sensorName r_arm_ft_imu

--- a/urdf/ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini
+++ b/urdf/ergoCub/conf/gazebo_ergocub_r_leg_ft_sensor_inertial.ini
@@ -1,4 +1,4 @@
 disableImplicitNetworkWrapper
 yarpDeviceName r_leg_ft_sensor_inertial_hardware_device
-parentLinkName r_leg
+parentLinkName r_hip_3
 sensorName r_leg_ft_imu


### PR DESCRIPTION
By checking if the modifications introduced by https://github.com/icub-tech-iit/ergocub-software/pull/253 were also working on the modern Gazebo, I found a mistake I made in https://github.com/icub-tech-iit/ergocub-software/pull/250.