### PR TITLE
Update conda binary packages section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,19 @@ Alternatively, if `YARP` has been installed using the [robotology-superbuild](ht
 
 ### Use conda binary packages
 
-This repository is packaged as `ergocub-software` in the `robotology` conda channel, see https://anaconda.org/robotology/ergocub-software .
+This repository is packaged as `ergocub-software` in the `conda-forge` conda channel, see https://anaconda.org/conda-forge/ergocub-software .
 
 To create an environment with it, just add it during the environment creation as any other conda package, for example:
 ~~~
-conda create -n ergocubenv -c conda-forge -c robotology ergocub-software
+conda create -n ergocubenv -c conda-forge ergocub-software
 ~~~
+
+If you only need to use the ergoCub URDF models and you do not want to install the full dependencies of the `ergocub-software` (that include YARP and OpenCV), you can also install the lightweigh dependency free package `ergocub-models`:
+~~~
+conda create -n ergocubenv -c conda-forge ergocub-models
+~~~
+
+The `ergocub-software` package depends on `ergocub-models`, so if you need both you can just install `ergocub-software`.
 
 ## Run Whole-body-dynamics
 Currently whole-body-dynamics does not run along with `ergoCubGazeboV1`. To start it please run the following command in a console once `yarpserver` and


### PR DESCRIPTION
I did not notice that the README still referred to the `robotology` channel, even if the `ergocub-software` package was moved to `conda-forge` in https://github.com/conda-forge/staged-recipes/pull/26175 . That was not a big problem as anyhow the conda-forge channel was present, but now we can simplify the structure of the docs.

Furthermore, I think we can also document the new lightweigth `ergocub-models` package introduced in https://github.com/conda-forge/ergocub-software-feedstock/pull/7 .

