### PR TITLE
Added possibility to draw basic circles and "stadiums" in the expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@
 # Build directory
 build*/
 
+# Visual studio
+.vs/*
+CMakeSettings.json

--- a/app/ergoCubEmotions/conf/config.ini
+++ b/app/ergoCubEmotions/conf/config.ini
@@ -2,7 +2,7 @@
 num_expressions 5
 num_transitions 20
 fullscreen true
-num_graphics 2
+num_graphics 3
 
 #[expression_0]
 #name neutral
@@ -151,13 +151,21 @@ file expressions/videos/shy-angry.mp4
 
 [graphic_0]
 type circle
-name ear
+name ear_r
 visible false
-center (120, 420)
+center (140, 420)
 radius 50
 color_rgb (255, 0, 0)
 
 [graphic_1]
+type circle
+name ear_l
+visible false
+center (2100, 420)
+radius 50
+color_rgb (255, 0, 0)
+
+[graphic_2]
 type stadium
 name mouth
 visible false

--- a/app/ergoCubEmotions/conf/config.ini
+++ b/app/ergoCubEmotions/conf/config.ini
@@ -2,6 +2,7 @@
 num_expressions 5
 num_transitions 20
 fullscreen true
+num_graphics 0
 
 #[expression_0]
 #name neutral
@@ -116,7 +117,7 @@ file expressions/videos/happy-angry.mp4
 [transition_13]
 source angry
 destination happy
-file expressions/videos/angry-happy.mp4     
+file expressions/videos/angry-happy.mp4
 
 [transition_14]
 source angry
@@ -147,3 +148,18 @@ file expressions/videos/alert-angry.mp4
 source shy
 destination angry
 file expressions/videos/shy-angry.mp4
+
+[graphic_0]
+type circle
+name ear
+center (120, 420)
+radius 50
+color_rgb (255, 0, 0)
+
+[graphic_1]
+type stadium
+name mouth
+center (1120, 800)
+width 200
+height 50
+color_rgb (227, 195, 93)

--- a/app/ergoCubEmotions/conf/config.ini
+++ b/app/ergoCubEmotions/conf/config.ini
@@ -2,7 +2,7 @@
 num_expressions 5
 num_transitions 20
 fullscreen true
-num_graphics 0
+num_graphics 2
 
 #[expression_0]
 #name neutral
@@ -152,6 +152,7 @@ file expressions/videos/shy-angry.mp4
 [graphic_0]
 type circle
 name ear
+visible false
 center (120, 420)
 radius 50
 color_rgb (255, 0, 0)
@@ -159,7 +160,8 @@ color_rgb (255, 0, 0)
 [graphic_1]
 type stadium
 name mouth
+visible false
 center (1120, 800)
-width 200
+width 100
 height 50
 color_rgb (227, 195, 93)

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
@@ -32,6 +32,7 @@ bool ErgoCubEmotions::configure(ResourceFinder& rf)
     nExpressions = bGroup.find("num_expressions").asInt32();
     nTransitions = bGroup.find("num_transitions").asInt32();
     fullscreen = bGroup.find("fullscreen").asBool();
+    int graphic_elements = bGroup.find("num_graphics").asInt32();
 
     for(int i = 0; i < nExpressions; i++)
     {
@@ -101,6 +102,31 @@ bool ErgoCubEmotions::configure(ResourceFinder& rf)
         {
             videoFileNames.push_back(filePath);
         }
+    }
+
+    for (int j = 0; j < graphic_elements; j++)
+    {
+        std::ostringstream element_j;
+        element_j << "graphic_" << j;
+        std::string group_name = element_j.str();
+        auto& elementGroup = rf.findGroup(group_name);
+        if (elementGroup.isNull())
+        {
+            yError() << "Missing group" << group_name;
+            return false;
+        }
+        auto element = GraphicElement::parse(elementGroup);
+        if (!element)
+        {
+            yError() << "Failed to parse graphic element" << group_name;
+            return false;
+        }
+        if (graphicElements.find(element->name) != graphicElements.end())
+        {
+            yError() << "Duplicate graphic element" << element->name;
+            return false;
+        }
+        graphicElements[element->name] = element;
     }
 
     isTransition = true;
@@ -175,8 +201,7 @@ bool ErgoCubEmotions::updateModule()
         else
         {
             img = img_tmp;
-            imshow("emotion", img);
-            pollKey();
+            updateFrame();
         }
     }
     else if(info.first == "video")
@@ -194,7 +219,7 @@ bool ErgoCubEmotions::updateModule()
                 cap = videoCaptures.at(i);
             }
         }
-        
+
         Mat frame;
 
         while(cap.isOpened())
@@ -202,10 +227,11 @@ bool ErgoCubEmotions::updateModule()
             cap >> frame;
             if(frame.empty())
             {
+                pollKey();
                 break;
             }
-            imshow("emotion", frame);
-            pollKey();
+            img = frame;
+            updateFrame();
         }
         cap.release();
     }
@@ -258,8 +284,8 @@ void ErgoCubEmotions::showTransition(const std::string& current, const std::stri
                 {
                     break;
                 }
-                imshow("emotion", frameTrans);
-                pollKey();
+                img = frameTrans;
+                updateFrame();
             }
             capTrans.release();
             return;
@@ -270,4 +296,203 @@ void ErgoCubEmotions::showTransition(const std::string& current, const std::stri
 std::vector<std::string> ErgoCubEmotions::availableEmotions()
 {
     return avlEmotions;
+}
+
+void ErgoCubEmotions::updateFrame()
+{
+    //Use a led for listening with different colors and an animation for speaking
+    //use one led also for thinking
+    imgEdited = img.clone();
+    for (auto& element : graphicElements)
+    {
+        element.second->draw(imgEdited);
+    }
+    imshow("emotion", imgEdited);
+    pollKey();
+}
+
+std::shared_ptr<GraphicElement> GraphicElement::parse(const yarp::os::Bottle& options)
+{
+    if (!options.check("type"))
+    {
+        yError() << "Missing type in options!";
+        return std::shared_ptr<GraphicElement>();
+    }
+    if (!options.check("name"))
+    {
+        yError() << "Missing name in options!";
+        return std::shared_ptr<GraphicElement>();
+    }
+
+    std::string name = options.find("name").asString();
+    std::string type = options.find("type").asString();
+    if (type == "circle")
+    {
+        std::shared_ptr<GraphicElement> output = Circle::parse(options);
+        output->name = name;
+        return output;
+    }
+    else if (type == "stadium")
+    {
+        std::shared_ptr<GraphicElement> output = Stadium::parse(options);
+        output->name = name;
+        return output;
+    }
+    else
+    {
+        yError() << "Unknown type" << type;
+        return std::shared_ptr<GraphicElement>();
+    }
+}
+
+Circle::Circle(cv::Point center, int radius, cv::Scalar color)
+    : center(center), radius(radius), color(color)
+{
+}
+
+void Circle::draw(cv::Mat& img)
+{
+    circle(img, center, radius, color, FILLED);
+}
+
+std::shared_ptr<GraphicElement> Circle::parse(const yarp::os::Bottle& options)
+{
+    if (!options.check("center"))
+    {
+        yError() << "Missing center option!";
+        return std::shared_ptr<GraphicElement>();
+    }
+    if (!options.check("radius"))
+    {
+        yError() << "Missing radius in options!";
+        return std::shared_ptr<GraphicElement>();
+    }
+    if (!options.check("color_rgb"))
+    {
+        yError() << "Missing color_rgb in options!";
+        return std::shared_ptr<GraphicElement>();
+    }
+
+    auto center = options.find("center").asList();
+    if (!center || center->size() != 2)
+    {
+        yError() << "Center must have 2 elements!";
+        return std::shared_ptr<GraphicElement>();
+    }
+    if (!center->get(0).isInt32() || !center->get(1).isInt32())
+    {
+        yError() << "Center elements must be integers!";
+        return std::shared_ptr<GraphicElement>();
+    }
+    cv::Point centerPoint(center->get(0).asInt32(), center->get(1).asInt32());
+
+    auto& radius = options.find("radius");
+    if (!radius.isInt32())
+    {
+        yError() << "Radius must be an integer!";
+        return std::shared_ptr<GraphicElement>();
+    }
+
+    auto color = options.find("color_rgb").asList();
+    if (!color || color->size() != 3)
+    {
+        yError() << "color_rgb must have 3 elements!";
+        return std::shared_ptr<GraphicElement>();
+    }
+    if (!color->get(0).isInt32() || !color->get(1).isInt32() || !color->get(2).isInt32())
+    {
+        yError() << "Color elements must be integers!";
+        return std::shared_ptr<GraphicElement>();
+    }
+    // RGB to BGR
+    cv::Scalar colorScalar(color->get(2).asInt32(), color->get(1).asInt32(), color->get(0).asInt32());
+    return std::make_shared<Circle>(centerPoint, radius.asInt32(), colorScalar);
+}
+
+Stadium::Stadium(cv::Point center, int height, int width, cv::Scalar color)
+    : center(center), height(height), width(width), color(color)
+{
+}
+
+void Stadium::draw(cv::Mat& img)
+{
+    // Calculate the radius of the semicircles
+    int radius = height / 2;
+
+    // Calculate the coordinates of the rectangle
+    Point rectTopLeft(center.x - width / 2, center.y - radius);
+    Point rectBottomRight(center.x + width / 2, center.y + radius);
+
+    // Draw the rectangle
+    rectangle(img, rectTopLeft, rectBottomRight, color, FILLED);
+
+    // Draw the semicircles
+    ellipse(img, Point(center.x - width / 2, center.y), Size(radius, radius), 270, 180, 360, color, FILLED);
+    ellipse(img, Point(center.x + width / 2, center.y), Size(radius, radius), 90, 180, 360, color, FILLED);
+}
+
+std::shared_ptr<GraphicElement> Stadium::parse(const yarp::os::Bottle& options)
+{
+    if (!options.check("center"))
+    {
+        yError() << "Missing center option!";
+        return std::shared_ptr<GraphicElement>();
+    }
+    if (!options.check("height"))
+    {
+        yError() << "Missing height in options!";
+        return std::shared_ptr<GraphicElement>();
+    }
+    if (!options.check("width"))
+    {
+        yError() << "Missing width in options!";
+        return std::shared_ptr<GraphicElement>();
+    }
+    if (!options.check("color_rgb"))
+    {
+        yError() << "Missing color_rgb in options!";
+        return std::shared_ptr<GraphicElement>();
+    }
+
+    auto center = options.find("center").asList();
+    if (!center || center->size() != 2)
+    {
+        yError() << "Center must have 2 elements!";
+        return std::shared_ptr<GraphicElement>();
+    }
+    if (!center->get(0).isInt32() || !center->get(1).isInt32())
+    {
+        yError() << "Center elements must be integers!";
+        return std::shared_ptr<GraphicElement>();
+    }
+    cv::Point centerPoint(center->get(0).asInt32(), center->get(1).asInt32());
+
+    auto& height = options.find("height");
+    if (!height.isInt32())
+    {
+        yError() << "Height must be an integer!";
+        return std::shared_ptr<GraphicElement>();
+    }
+
+    auto& width = options.find("width");
+    if (!width.isInt32())
+    {
+        yError() << "Width must be an integer!";
+        return std::shared_ptr<GraphicElement>();
+    }
+
+    auto color = options.find("color_rgb").asList();
+    if (!color || color->size() != 3)
+    {
+        yError() << "color_rgb must have 3 elements!";
+        return std::shared_ptr<GraphicElement>();
+    }
+    if (!color->get(0).isInt32() || !color->get(1).isInt32() || !color->get(2).isInt32())
+    {
+        yError() << "Color elements must be integers!";
+        return std::shared_ptr<GraphicElement>();
+    }
+    // RGB to BGR
+    cv::Scalar colorScalar(color->get(2).asInt32(), color->get(1).asInt32(), color->get(0).asInt32());
+    return std::make_shared<Stadium>(centerPoint, height.asInt32(), width.asInt32(), colorScalar);
 }

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.h
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.h
@@ -29,6 +29,7 @@ class GraphicElement
 {
 public:
     std::string name;
+    std::atomic<bool> visible {true};
 
     virtual void draw(cv::Mat& img) = 0;
 
@@ -71,15 +72,18 @@ public:
     ErgoCubEmotions();
     ~ErgoCubEmotions();
 
-    bool attach(yarp::os::RpcServer &source);
-    bool configure(yarp::os::ResourceFinder &config);
-    bool close();
-    bool updateModule();
-    double getPeriod();
+    bool attach(yarp::os::RpcServer &source) override;
+    bool configure(yarp::os::ResourceFinder &config) override;
+    bool close() override;
+    bool updateModule() override;
+    double getPeriod() override;
 
-    bool setEmotion(const std::string &command);
-    std::vector<std::string> availableEmotions();
+    bool setEmotion(const std::string &command) override;
+    std::vector<std::string> availableEmotions() override;
     void showTransition(const std::string &current, const std::string &desired);
+
+    bool setGraphicVisibility(const std::string& name, const bool visible) override;
+    std::vector<std::string> availableGraphics() override;
 
     void updateFrame();
 

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.h
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.h
@@ -29,7 +29,9 @@ class GraphicElement
 {
 public:
     std::string name;
+    cv::Scalar color; //BGR
     std::atomic<bool> visible {true};
+    std::mutex mutex;
 
     virtual void draw(cv::Mat& img) = 0;
 
@@ -41,10 +43,6 @@ class Circle : public GraphicElement
 public:
     cv::Point center;
     int radius;
-    cv::Scalar color; //BGR
-
-    Circle() = default;
-    Circle(cv::Point center, int radius, cv::Scalar color);
 
     void draw(cv::Mat& img) override;
 
@@ -56,10 +54,6 @@ struct Stadium : public GraphicElement
     cv::Point center;
     int height;
     int width;
-    cv::Scalar color; //BGR
-
-    Stadium() = default;
-    Stadium(cv::Point center, int height, int width, cv::Scalar color);
 
     void draw(cv::Mat& img) override;
 
@@ -83,6 +77,7 @@ public:
     void showTransition(const std::string &current, const std::string &desired);
 
     bool setGraphicVisibility(const std::string& name, const bool visible) override;
+    bool setGraphicColor(const std::string& name, const double r, const double g, const double b) override;
     std::vector<std::string> availableGraphics() override;
 
     void updateFrame();

--- a/src/modules/ergoCubEmotions/idl.thrift
+++ b/src/modules/ergoCubEmotions/idl.thrift
@@ -40,6 +40,17 @@ service ergoCubEmotions_IDL
         bool setGraphicVisibility(1:string name, 2:bool visible);
 
         /**
+        * Change the color of a specific graphic.
+        * @param name is the name of the graphic that will be set.
+        * @note Colors are in the range [0, 255].
+        * @param r is the red component of the color.
+        * @param g is the green component of the color.
+        * @param b is the blue component of the color.
+        * @return true/false on success/failure.
+        */
+        bool setGraphicColor(1:string name, 2:double r, 3:double g, 4:double b);
+
+        /**
         * Print the list of all the available graphics.
         * @return a list of names.
         */

--- a/src/modules/ergoCubEmotions/idl.thrift
+++ b/src/modules/ergoCubEmotions/idl.thrift
@@ -30,4 +30,18 @@ service ergoCubEmotions_IDL
         * @return a list of commands.
         */
         list<string> availableEmotions();
+
+        /**
+        * Change the visibility of a specific graphic.
+        * @param name is the name of the graphic that will be set.
+        * @param visible is the visibility of the graphic.
+        * @return true/false on success/failure.
+        */
+        bool setGraphicVisibility(1:string name, 2:bool visible);
+
+        /**
+        * Print the list of all the available graphics.
+        * @return a list of names.
+        */
+        list<string> availableGraphics();
 }


### PR DESCRIPTION
With this PR it is possible to draw simple elements in the expressions. 

At the moment I only added circles and "stadiums". It is possible to toggle the visibility and change the color from RPC

This is the result


https://github.com/user-attachments/assets/b231aab7-2323-4a0d-bd92-fe1aaa08efb2

