### PR TITLE
Looping and preload of all media

### DIFF
--- a/app/ergoCubEmotions/conf/config.ini
+++ b/app/ergoCubEmotions/conf/config.ini
@@ -27,26 +27,31 @@ num_graphics 3
 [expression_0]
 name neutral
 type video
+loop false
 file expressions/videos/neutral.mp4
 
 [expression_1]
 name happy
 type video
+loop false
 file expressions/videos/happy.mp4
 
 [expression_2]
 name alert
 type video
+loop false
 file expressions/videos/alert.mp4
 
 [expression_3]
 name shy
 type video
+loop false
 file expressions/videos/shy.mp4
 
 [expression_4]
 name angry
 type video
+loop false
 file expressions/videos/angry.mp4
 
 [transition_0]

--- a/app/ergoCubEmotions/conf/config.ini
+++ b/app/ergoCubEmotions/conf/config.ini
@@ -3,6 +3,7 @@ num_expressions 5
 num_transitions 20
 fullscreen true
 num_graphics 3
+default neutral
 
 #[expression_0]
 #name neutral

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
@@ -34,6 +34,14 @@ bool ErgoCubEmotions::configure(ResourceFinder& rf)
     fullscreen = bGroup.find("fullscreen").asBool();
     int graphic_elements = bGroup.find("num_graphics").asInt32();
 
+    if (nExpressions <= 0)
+    {
+        yError() << "Number of expressions must be greater than 0!";
+        return false;
+    }
+
+    std::string defaultExpression = bGroup.find("default").asString();
+
     for(int i = 0; i < nExpressions; i++)
     {
         std::ostringstream expression_i;
@@ -48,6 +56,11 @@ bool ErgoCubEmotions::configure(ResourceFinder& rf)
         std::string type = bExpression.find("type").asString();
         std::string file = bExpression.find("file").asString();
         std::string filePath = rf.findFile(file);
+
+        if (defaultExpression.empty())
+        {
+            defaultExpression = name;
+        }
 
         if (filePath.empty())
         {
@@ -176,7 +189,12 @@ bool ErgoCubEmotions::configure(ResourceFinder& rf)
     }
 
     isTransition = true;
-    command = "neutral";
+    if (emotions.find(defaultExpression) == emotions.end())
+    {
+        yError() << "The default expression " << defaultExpression << "has not been found!";
+        return false;
+    }
+    command = defaultExpression;
 
     if(fullscreen){
         namedWindow("emotion", WND_PROP_FULLSCREEN);

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
@@ -403,9 +403,15 @@ std::vector<std::string> ErgoCubEmotions::availableEmotions()
 void ErgoCubEmotions::updateFrame(bool image_updated)
 {
     //Update only if some graphic elements are visible and to update
+    bool graphics_visible = false;
     bool graphics_to_update = false;
     for (auto& element : graphicElements)
     {
+        if (element.second->visible)
+        {
+            graphics_visible = true;
+        }
+
         if (element.second->visible && element.second->updated)
         {
             graphics_to_update = true;
@@ -413,12 +419,19 @@ void ErgoCubEmotions::updateFrame(bool image_updated)
         }
     }
 
-    if (!graphics_to_update)
+    if (!graphics_visible)
     {
         if (image_updated)
         {
             imshow("emotion", img);
         }
+        pollKey();
+        return;
+    }
+
+    if (graphics_visible && !graphics_to_update && !image_updated)
+    {
+        imshow("emotion", imgEdited);
         pollKey();
         return;
     }

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
@@ -258,7 +258,7 @@ bool ErgoCubEmotions::updateModule()
             return false;
         }
         auto current_it = emotions.find(currentCommand);
-        if (current_it != emotions.end())
+        if (current_it != emotions.end() && currentCommand != command)
         {
             current_it->second->restart();
         }
@@ -270,7 +270,7 @@ bool ErgoCubEmotions::updateModule()
 
     if (!source)
     {
-        yError() << "Unknown emotion" << command_local;
+        yError() << "The source of" << command_local << "is empty. It should not have happened.";
         return false;
     }
 

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
@@ -362,11 +362,8 @@ bool ErgoCubEmotions::setGraphicVisibility(const std::string& name, const bool v
         yError() << "Unknown graphic element" << name;
         return false;
     }
+    element->second->updated = element->second->visible != visible;
     element->second->visible = visible;
-    if (visible)
-    {
-        element->second->updated = true;
-    }
     return true;
 }
 
@@ -412,26 +409,29 @@ void ErgoCubEmotions::updateFrame(bool image_updated)
             graphics_visible = true;
         }
 
-        if (element.second->visible && element.second->updated)
+        if (element.second->updated)
         {
             graphics_to_update = true;
-            break;
         }
     }
 
-    if (!graphics_visible)
+    if (!graphics_visible && !graphics_to_update)
     {
         if (image_updated)
         {
+            // Only update the frame if there is a new image
+            // and no graphic elements are visible
+            // and have not been updated
             imshow("emotion", img);
         }
         pollKey();
         return;
     }
 
-    if (graphics_visible && !graphics_to_update && !image_updated)
+    if (!graphics_to_update && !image_updated)
     {
-        imshow("emotion", imgEdited);
+        // The image is not updated, nor the graphics
+        // so do not update the frame
         pollKey();
         return;
     }

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
@@ -647,6 +647,10 @@ bool VideoSource::open(const std::string& path)
 
 cv::Mat VideoSource::newImage()
 {
+    if (shouldRestart)
+    {
+        return cv::Mat();
+    }
     double currentTime = yarp::os::Time::now();
     if (lastFrameTime > 0.0)
     {
@@ -656,6 +660,7 @@ cv::Mat VideoSource::newImage()
     }
     cap >> frame;
     lastFrameTime = yarp::os::Time::now();
+    shouldRestart = frame.empty();
     return frame;
 }
 
@@ -663,6 +668,7 @@ void VideoSource::restart()
 {
     cap.set(CAP_PROP_POS_MSEC, 0.0);
     lastFrameTime = -1.0;
+    shouldRestart = false;
 }
 
 bool ImageSource::open(const std::string& path)

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
@@ -231,6 +231,13 @@ double ErgoCubEmotions::getPeriod()
     return 1.0;
 }
 
+bool ErgoCubEmotions::interruptModule()
+{
+    //Exits the while loops in updateModule
+    shouldUpdate = true;
+    return true;
+}
+
 bool ErgoCubEmotions::updateModule()
 {
     bool isTransition_local;

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
@@ -183,6 +183,7 @@ bool ErgoCubEmotions::updateModule()
             currentCommand = command;
         }
         isTransition = false;
+        shouldUpdate = false;
     }
 
 
@@ -222,7 +223,7 @@ bool ErgoCubEmotions::updateModule()
 
         Mat frame;
 
-        while(cap.isOpened())
+        while(cap.isOpened() && !shouldUpdate)
         {
             cap >> frame;
             if(frame.empty())
@@ -235,7 +236,7 @@ bool ErgoCubEmotions::updateModule()
             img = frame;
             updateFrame();
         }
-        cap.release();
+        cap.set(CAP_PROP_POS_MSEC, 0.0); //Restart the video
     }
 
     return true;
@@ -252,12 +253,16 @@ bool ErgoCubEmotions::setEmotion(const std::string& command)
     }
 
     this->command = command;
-    isTransition = true;
 
     if (currentCommand == command)
     {
         yWarning() << command << "is already set!";
         isTransition = false;
+    }
+    else
+    {
+        isTransition = true;
+        shouldUpdate = true;
     }
 
     return true;
@@ -279,7 +284,7 @@ void ErgoCubEmotions::showTransition(const std::string& current, const std::stri
             }
             Mat frameTrans;
 
-            while(capTrans.isOpened())
+            while(capTrans.isOpened() && !shouldUpdate)
             {
                 capTrans >> frameTrans;
                 if(frameTrans.empty())

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.cpp
@@ -49,6 +49,15 @@ bool ErgoCubEmotions::configure(ResourceFinder& rf)
         std::string file = bExpression.find("file").asString();
         std::string filePath = rf.findFile(file);
 
+        if (filePath.empty())
+        {
+            yError() << "The path for the file" << file
+                     << "for the emotion" << name
+                     << "got resolved to an empty path."
+                     << " The specified file may not exist.";
+            return false;
+        }
+
         avlEmotions.emplace_back(name);
 
         if(std::count(avlEmotions.begin(), avlEmotions.end(), name) > 1)
@@ -62,8 +71,15 @@ bool ErgoCubEmotions::configure(ResourceFinder& rf)
 
         if(!(std::count(videoFileNames.begin(), videoFileNames.end(), filePath)))
         {
+            VideoCapture cap;
+            if (!cap.open(filePath))
+            {
+                yError() << "Could not open the file" << file
+                         << "with path" << filePath
+                         << "for the expression" << name;
+                return false;
+            }
             videoFileNames.push_back(filePath);
-            VideoCapture cap(filePath);
             videoCaptures.push_back(cap);
         }
     }

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.h
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.h
@@ -87,6 +87,7 @@ public:
     int nTransitions;
     bool isTransition;
     bool fullscreen;
+    std::atomic<bool> shouldUpdate { false };
     std::unordered_map<std::string, std::pair<std::string, std::string>> imgMap;
     std::map<std::pair<std::string, std::string>, std::string> transitionMap;
     std::string command;

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.h
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.h
@@ -64,6 +64,7 @@ public:
 class Source
 {
 public:
+    bool loop{ false };
     virtual cv::Mat newImage() = 0;
     virtual void restart() = 0;
 };

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.h
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.h
@@ -103,6 +103,8 @@ public:
     bool close() override;
     bool updateModule() override;
     double getPeriod() override;
+    bool interruptModule() override;
+
 
     bool setEmotion(const std::string &command) override;
     std::vector<std::string> availableEmotions() override;

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.h
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.h
@@ -72,6 +72,9 @@ class VideoSource : public Source
 {
     cv::VideoCapture cap;
     cv::Mat frame;
+    double fps {30.0};
+    double lastFrameTime{ -1.0 };
+
 public:
     bool open(const std::string& path);
     cv::Mat newImage() override;

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.h
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.h
@@ -76,6 +76,7 @@ class VideoSource : public Source
     cv::Mat frame;
     double fps {30.0};
     double lastFrameTime{ -1.0 };
+    bool shouldRestart{ false };
 
 public:
     bool open(const std::string& path);

--- a/src/modules/ergoCubEmotions/ergoCubEmotions.h
+++ b/src/modules/ergoCubEmotions/ergoCubEmotions.h
@@ -31,6 +31,7 @@ public:
     std::string name;
     cv::Scalar color; //BGR
     std::atomic<bool> visible {true};
+    std::atomic<bool> updated{ true };
     std::mutex mutex;
 
     virtual void draw(cv::Mat& img) = 0;
@@ -114,7 +115,7 @@ public:
     bool setGraphicColor(const std::string& name, const double r, const double g, const double b) override;
     std::vector<std::string> availableGraphics() override;
 
-    void updateFrame();
+    void updateFrame(bool image_updated);
 
     yarp::os::RpcServer cmdPort;
     int nExpressions;


### PR DESCRIPTION
Before the actual video was shown only once, but the correct emotion was displayed because it was the last frame of the corresponding transition.

Also, I exploited maps instead of vectors to look for the available transitions.