### PR TITLE
Change default value of ALLOW_DEVICE_PARAM_PARSER_GENERATION based on YARP version to support both YARP 3.11 and 3.12

### DIFF
--- a/src/modules/couplingXCubHandMk5/CMakeLists.txt
+++ b/src/modules/couplingXCubHandMk5/CMakeLists.txt
@@ -6,6 +6,18 @@
 
 yarp_configure_plugins_installation(ergocub-software)
 
+# The committed versions of the param parsers is not compatible with YARP 3.12.0, so depending on the YARP version we set
+# the option to automatically run the generator to ON if we detect an incompatible YARP version. This can be changed when
+# compatibility with YARP 3.11 is dropped and YARP 3.12 compatible param parser are generated
+if(YARP_VERSION VERSION_LESS 3.11.100)
+  set(ALLOW_DEVICE_PARAM_PARSER_GENERATION_DEFAULT_VALUE OFF)
+else()
+  set(ALLOW_DEVICE_PARAM_PARSER_GENERATION_DEFAULT_VALUE ON)
+endif()
+# This must be before the call to yarp_prepare_plugin, otherwise the default value specified there
+# will override the default value specified here
+option(ALLOW_DEVICE_PARAM_PARSER_GENERATION "Generate the param parser for couplingXCubHandMk5 device" ${ALLOW_DEVICE_PARAM_PARSER_GENERATION_DEFAULT_VALUE})
+
 yarp_prepare_plugin(couplingXCubHandMk5
                     CATEGORY device
                     TYPE CouplingXCubHandMk5
@@ -14,7 +26,6 @@ yarp_prepare_plugin(couplingXCubHandMk5
                     DEFAULT ON)
 
 if(ENABLE_couplingXCubHandMk5)
-  option(ALLOW_DEVICE_PARAM_PARSER_GENERATION "Generate the param parser for couplingXCubHandMk5 device" OFF)
   yarp_add_plugin(yarp_couplingXCubHandMk5)
 
   if(MSVC)


### PR DESCRIPTION
YARP 3.12 will be released with a change for which the device param parser generators generated by YARP 3.11 (and that are committed in this repo) do not work with YARP 3.12, see also https://github.com/robotology/yarp/pull/3225 . A simple trick to easily support both YARP 3.11 and 3.12 (to simplify migrations) is to change the default value of `ALLOW_DEVICE_PARAM_PARSER_GENERATION` (the CMake option that enables the generation of the device param parsers) to `ON` if YARP 3.12 is used. 

In this way, 3.11 users will continue to be able to use the committed version of the files, while YARP 3.12 users will still be able to compile, with the downside that they will have non-committed files that should pay attention not to commit. A possible alternative solution is to generate the device param parser file in a location not in the source directory, but this is not currently supported by the YARP's macro related to device param parser generation.

Part of https://github.com/robotology/robotology-superbuild/issues/1854 .





