### PR TITLE
joint-open-loop-move improvement

### DIFF
--- a/src/tools/joint-pid-tuning/cpp/joint-open-loop-move/main.cpp
+++ b/src/tools/joint-pid-tuning/cpp/joint-open-loop-move/main.cpp
@@ -103,7 +103,7 @@ public:
   bool isDone() { return done_h && done_l; }
 
   void setInputs(double pwm) {
-  pwm_.store(pwm);
+    pwm_.store(pwm);
   }
 
   void resetFlags() {


### PR DESCRIPTION
Bugfix open-loop-move code, the target is sent more often to `yarp` to avoid getting a timeout error.

edit: 
~~Introduced a new optional parameter `--reverse`, which should be used when a positive PWM causes the motor encoder value to increase while the joint encoder value decreases.~~


cc @MSECode @AntonioViscomi @fgarini 