### PR TITLE
Remove version requirement for YARP package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.12)
 project(ergocub-software LANGUAGES C CXX
                          VERSION 0.7.11)
 
-find_package(YARP 3.12.0 COMPONENTS conf os sig dev math idl_tools REQUIRED)
+find_package(YARP COMPONENTS conf os sig dev math idl_tools REQUIRED)
 
 # Give error if add_dependencies is called on a non-existing target
 if(POLICY CMP0046)


### PR DESCRIPTION
This is for the migration to YARP4.

see:
- https://github.com/robotology/robotology-superbuild/pull/1945