### PR TITLE
Fixed YARP4 compatiblity for joint-pid-tuning

### DIFF
--- a/src/tools/joint-pid-tuning/cpp/joint-open-loop-move/main.cpp
+++ b/src/tools/joint-pid-tuning/cpp/joint-open-loop-move/main.cpp
@@ -126,7 +126,11 @@ bool resetPosition(uint8_t j) {
   bool done = false;
 
   while (!done) {
+    #if YARP_VERSION_MAJOR >= 4
     iPos->checkMotionDone(j, done);
+    #else
+    iPos->checkMotionDone(j, &done);
+    #endif
     Time::yield();
   }
 

--- a/src/tools/joint-pid-tuning/cpp/joint-open-loop-move/main.cpp
+++ b/src/tools/joint-pid-tuning/cpp/joint-open-loop-move/main.cpp
@@ -52,7 +52,7 @@ private:
   bool done_l = false;
   DataExperiment data;
   uint8_t j = 0;
-  std::atomic<double> pwm_{0.0};  
+  std::atomic<double> pwm_{0.0};
   double thr_min = 0;
   double thr_max = 0;
   double t0 = 0;
@@ -126,7 +126,7 @@ bool resetPosition(uint8_t j) {
   bool done = false;
 
   while (!done) {
-    iPos->checkMotionDone(j, &done);
+    iPos->checkMotionDone(j, done);
     Time::yield();
   }
 

--- a/src/tools/joint-pid-tuning/cpp/joint-position-move/main.cpp
+++ b/src/tools/joint-pid-tuning/cpp/joint-position-move/main.cpp
@@ -97,7 +97,7 @@ int main(int argc, char * argv[])
     auto cycle_done{ false };
 
     while (!done) {
-        iPos->checkMotionDone(joint_id, &done);
+        iPos->checkMotionDone(joint_id, done);
         Time::yield();
     }
 
@@ -134,7 +134,7 @@ int main(int argc, char * argv[])
                 iEnc->getEncoder(joint_id, &data.enc);
 
                 if (Time::now() - t1 >= 0.01) {
-                    iPos->checkMotionDone(joint_id, &done);
+                    iPos->checkMotionDone(joint_id, done);
                     t1 = Time::now();
 
                     if(done)
@@ -178,7 +178,7 @@ int main(int argc, char * argv[])
     #endif
     iPos->positionMove(joint_id, 0.);
     while (!done) {
-        iPos->checkMotionDone(joint_id, &done);
+        iPos->checkMotionDone(joint_id, done);
         Time::yield();
     }
 

--- a/src/tools/joint-pid-tuning/cpp/joint-position-move/main.cpp
+++ b/src/tools/joint-pid-tuning/cpp/joint-position-move/main.cpp
@@ -97,7 +97,11 @@ int main(int argc, char * argv[])
     auto cycle_done{ false };
 
     while (!done) {
+        #if YARP_VERSION_MAJOR >= 4
         iPos->checkMotionDone(joint_id, done);
+        #else
+        iPos->checkMotionDone(joint_id, &done);
+        #endif
         Time::yield();
     }
 
@@ -134,7 +138,11 @@ int main(int argc, char * argv[])
                 iEnc->getEncoder(joint_id, &data.enc);
 
                 if (Time::now() - t1 >= 0.01) {
+                    #if YARP_VERSION_MAJOR >= 4
                     iPos->checkMotionDone(joint_id, done);
+                    #else
+                    iPos->checkMotionDone(joint_id, &done);
+                    #endif
                     t1 = Time::now();
 
                     if(done)
@@ -178,7 +186,11 @@ int main(int argc, char * argv[])
     #endif
     iPos->positionMove(joint_id, 0.);
     while (!done) {
+        #if YARP_VERSION_MAJOR >= 4
         iPos->checkMotionDone(joint_id, done);
+        #else
+        iPos->checkMotionDone(joint_id, &done);
+        #endif
         Time::yield();
     }
 


### PR DESCRIPTION
A simple fix of a set of calls to `IPositionControl::checkMotionDone` which changed declaration with this PR: [#3335](https://github.com/robotology/yarp/pull/3335)